### PR TITLE
Changed proxy type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,12 +15,18 @@
     ],
     "minimum-stability": "dev",
     "prefer-stable": true,
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/petr-buchin/ProxyManager"
+        }
+    ],
     "require": {
         "php": "~8.0",
         "ext-json": "*",
         "symfony/yaml": "~5.2",
         "dealroadshow/k8s-resources": "^1.16 || ^1.17 || ^1.18 || ^1.19",
-        "ocramius/proxy-manager": "~2.11"
+        "ocramius/proxy-manager": "dev-non-nullable-typed-properties-support"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "~8.0",
         "ext-json": "*",
-        "symfony/yaml": "~5.2",
+        "symfony/yaml": "5.3.*",
         "dealroadshow/k8s-resources": "^1.16 || ^1.17 || ^1.18 || ^1.19",
         "ocramius/proxy-manager": "dev-non-nullable-typed-properties-support",
         "ext-mbstring": "*"

--- a/src/Middleware/ManifestMethodPrefixMiddlewareInterface.php
+++ b/src/Middleware/ManifestMethodPrefixMiddlewareInterface.php
@@ -6,5 +6,5 @@ use Dealroadshow\K8S\Framework\Core\ManifestInterface;
 
 interface ManifestMethodPrefixMiddlewareInterface extends ManifestMethodMiddlewareInterface
 {
-    public function beforeMethodCall(ManifestInterface $proxy, ManifestInterface $manifest, string $methodName, array $params, mixed &$returnValue);
+    public function beforeMethodCall(ManifestInterface $proxy, string $methodName, array $params, mixed &$returnValue);
 }

--- a/src/Middleware/ManifestMethodSuffixMiddlewareInterface.php
+++ b/src/Middleware/ManifestMethodSuffixMiddlewareInterface.php
@@ -6,5 +6,5 @@ use Dealroadshow\K8S\Framework\Core\ManifestInterface;
 
 interface ManifestMethodSuffixMiddlewareInterface extends ManifestMethodMiddlewareInterface
 {
-    public function afterMethodCall(ManifestInterface $proxy, ManifestInterface $manifest, string $methodName, array $params, mixed $returnedValue, mixed &$returnValue);
+    public function afterMethodCall(ManifestInterface $proxy, string $methodName, array $params, mixed $returnedValue, mixed &$returnValue);
 }

--- a/src/Middleware/ManifestMiddlewareService.php
+++ b/src/Middleware/ManifestMiddlewareService.php
@@ -14,12 +14,12 @@ class ManifestMiddlewareService
     {
     }
 
-    public function beforeMethodCall(ManifestInterface $proxy, ManifestInterface $manifest, string $methodName, array $params): mixed
+    public function beforeMethodCall(ManifestInterface $proxy, string $methodName, array $params): mixed
     {
         foreach ($this->prefixMiddlewares as $middleware) {
-            if ($middleware->supports($manifest, $methodName, $params)) {
+            if ($middleware->supports($proxy, $methodName, $params)) {
                 $returnValue = ManifestMethodPrefixMiddlewareInterface::NO_RETURN_VALUE;
-                $middleware->beforeMethodCall($proxy, $manifest, $methodName, $params, $returnValue);
+                $middleware->beforeMethodCall($proxy, $methodName, $params, $returnValue);
                 if (ManifestMethodMiddlewareInterface::NO_RETURN_VALUE !== $returnValue) {
                     return $returnValue;
                 }
@@ -29,12 +29,12 @@ class ManifestMiddlewareService
         return ManifestMethodPrefixMiddlewareInterface::NO_RETURN_VALUE;
     }
 
-    public function afterMethodCall(ManifestInterface $proxy, ManifestInterface $manifest, string $methodName, array $params, mixed $returnedValue): mixed
+    public function afterMethodCall(ManifestInterface $proxy, string $methodName, array $params, mixed $returnedValue): mixed
     {
         foreach ($this->suffixMiddlewares as $middleware) {
-            if ($middleware->supports($manifest, $methodName, $params)) {
+            if ($middleware->supports($proxy, $methodName, $params)) {
                 $returnValue = ManifestMethodPrefixMiddlewareInterface::NO_RETURN_VALUE;
-                $middleware->afterMethodCall($proxy, $manifest, $methodName, $params, $returnedValue, $returnValue);
+                $middleware->afterMethodCall($proxy, $methodName, $params, $returnedValue, $returnValue);
                 if (ManifestMethodMiddlewareInterface::NO_RETURN_VALUE !== $returnValue) {
                     return $returnValue;
                 }

--- a/src/Proxy/ManifestProxyFactory.php
+++ b/src/Proxy/ManifestProxyFactory.php
@@ -6,7 +6,7 @@ use Dealroadshow\K8S\Framework\Core\ManifestInterface;
 use Dealroadshow\K8S\Framework\Middleware\ManifestMethodMiddlewareInterface;
 use Dealroadshow\K8S\Framework\Middleware\ManifestMethodPrefixMiddlewareInterface;
 use Dealroadshow\K8S\Framework\Middleware\ManifestMiddlewareService;
-use ProxyManager\Factory\AccessInterceptorValueHolderFactory as ProxyFactory;
+use ProxyManager\Factory\AccessInterceptorScopeLocalizerFactory as ProxyFactory;
 
 class ManifestProxyFactory
 {
@@ -20,12 +20,11 @@ class ManifestProxyFactory
 
         $prefixClosure = function(
             ManifestInterface $proxy,
-            ManifestInterface $wrapped,
             string $method,
             array $params,
             bool &$returnEarly
         ) {
-            $result = $this->middlewareService->beforeMethodCall($proxy, $wrapped, $method, $params);
+            $result = $this->middlewareService->beforeMethodCall($proxy, $method, $params);
             if (ManifestMethodPrefixMiddlewareInterface::NO_RETURN_VALUE !== $result) {
                 $returnEarly = true;
             }
@@ -35,13 +34,12 @@ class ManifestProxyFactory
 
         $suffixClosure = function(
             ManifestInterface $proxy,
-            ManifestInterface $wrapped,
             string $method,
             array $params,
             mixed $returnedValue,
             bool &$returnEarly
         ) {
-            $result = $this->middlewareService->afterMethodCall($proxy, $wrapped, $method, $params, $returnedValue);
+            $result = $this->middlewareService->afterMethodCall($proxy, $method, $params, $returnedValue);
             if (ManifestMethodMiddlewareInterface::NO_RETURN_VALUE !== $result) {
                 $returnEarly = true;
             }

--- a/src/Proxy/ManifestProxyFactory.php
+++ b/src/Proxy/ManifestProxyFactory.php
@@ -20,6 +20,7 @@ class ManifestProxyFactory
 
         $prefixClosure = function(
             ManifestInterface $proxy,
+            ManifestInterface $proxyAgain,
             string $method,
             array $params,
             bool &$returnEarly
@@ -34,6 +35,7 @@ class ManifestProxyFactory
 
         $suffixClosure = function(
             ManifestInterface $proxy,
+            ManifestInterface $proxyAgain,
             string $method,
             array $params,
             mixed $returnedValue,


### PR DESCRIPTION
This PR introduces changes in what type of proxy we use: we're moving to `AccessInterceptorScopeLocalizer`, since it allows to intercept calls on `$this` in object methods.