### PR TITLE
Fix in Image class

### DIFF
--- a/src/Core/Container/Image/Image.php
+++ b/src/Core/Container/Image/Image.php
@@ -49,7 +49,12 @@ class Image
         }
         $fullName .= $this->name;
         if (null !== $this->tag) {
-            $fullName .= ':'.$this->tag;
+            $separator = ':';
+            if (str_contains($this->tag, ':')) {
+                $separator = '@';
+            }
+
+            $fullName .= $separator.$this->tag;
         }
 
         return $fullName;


### PR DESCRIPTION
This PR fixes `Image` class so that it compiles to a valid image name, when image tag contains `:` symbol