### PR TITLE
CronJobInterface::suspendCronJob() method

### DIFF
--- a/src/Core/CronJob/AbstractCronJob.php
+++ b/src/Core/CronJob/AbstractCronJob.php
@@ -36,9 +36,9 @@ abstract class AbstractCronJob extends AbstractJob implements CronJobInterface
         return null;
     }
 
-    public function suspend(): bool
+    public function suspendCronJob(): bool
     {
-        return false;
+        return $this->suspend();
     }
 
     public function priorityClass(PriorityClassConfigurator $priorityClass): void

--- a/src/Core/CronJob/CronJobInterface.php
+++ b/src/Core/CronJob/CronJobInterface.php
@@ -16,4 +16,5 @@ interface CronJobInterface extends JobInterface
     public function startingDeadlineSeconds(): ?int;
     public function successfulJobsHistoryLimit(): ?int;
     public function configureCronJob(CronJob $cronJob): void;
+    public function suspendCronJob(): bool;
 }

--- a/src/ResourceMaker/CronJobMaker.php
+++ b/src/ResourceMaker/CronJobMaker.php
@@ -38,7 +38,7 @@ class CronJobMaker extends AbstractResourceMaker
         $failedJobsHistoryLimit = $manifest->failedJobsHistoryLimit();
         $startingDeadlineSeconds = $manifest->startingDeadlineSeconds();
         $successfulJobsHistoryLimit = $manifest->successfulJobsHistoryLimit();
-        $suspend = $manifest->suspend();
+        $spec->setSuspend($manifest->suspendCronJob());
         $spec->setConcurrencyPolicy($concurrencyPolicy->toString());
         if (null !== $failedJobsHistoryLimit) {
             $spec->setFailedJobsHistoryLimit($failedJobsHistoryLimit);
@@ -48,9 +48,6 @@ class CronJobMaker extends AbstractResourceMaker
         }
         if (null !== $successfulJobsHistoryLimit) {
             $spec->setSuccessfulJobsHistoryLimit($successfulJobsHistoryLimit);
-        }
-        if (null !== $suspend) {
-            $spec->setSuspend($suspend);
         }
         $manifest->configureCronJob($cronJob);
 


### PR DESCRIPTION
Adds separate method `CronJobInterface::suspendCronJob()` method in order to be able set different values of `suspend` field in `CronJob` and it's underlying job template