### PR TITLE
feat: prettify() method for CPU and Memory classes

### DIFF
--- a/src/Core/Container/Resources/CPU.php
+++ b/src/Core/Container/Resources/CPU.php
@@ -58,6 +58,11 @@ final readonly class CPU implements \JsonSerializable
         );
     }
 
+    public function prettify(): self
+    {
+        return new self(self::format($this->millicoresNumber()));
+    }
+
     public static function millicores(int $millicoresNumber): self
     {
         $value = strval($millicoresNumber).self::MILLICORES_SUFFIX;

--- a/src/Core/Container/Resources/Memory.php
+++ b/src/Core/Container/Resources/Memory.php
@@ -127,6 +127,11 @@ final readonly class Memory implements \JsonSerializable
         return $number * self::SUFFIX_MULTIPLIERS[$suffix];
     }
 
+    public function prettify(): self
+    {
+        return new self(self::format($this->bytesNumber()));
+    }
+
     public static function fromString(string $string): self
     {
         if (is_numeric($string)) {


### PR DESCRIPTION
Adds `prettify()` method for `CPU` and `Memory` classes, that allow this objects' values to be displayed prettier (in adequate units rather than bytes)