### PR TITLE
Adaptation to new k8s-resources

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=8.2",
         "ext-json": "*",
         "symfony/yaml": ">=6.0",
-        "dealroadshow/k8s-resources": "^1.27 || ^1.28 || ^1.29 || ^1.30",
+        "dealroadshow/k8s-resources": "dev-v1.30-new",
         "ext-mbstring": "*",
         "composer/semver": "^3.2",
         "psr/event-dispatcher": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=8.2",
         "ext-json": "*",
         "symfony/yaml": ">=6.0",
-        "dealroadshow/k8s-resources": "dev-v1.30-new",
+        "dealroadshow/k8s-resources": "v1.30.x-dev",
         "ext-mbstring": "*",
         "composer/semver": "^3.2",
         "psr/event-dispatcher": "^1.0",

--- a/src/App/AppProcessor.php
+++ b/src/App/AppProcessor.php
@@ -10,7 +10,7 @@ use Dealroadshow\K8S\Framework\Registry\AppRegistry;
 use Dealroadshow\K8S\Framework\Registry\ManifestRegistry;
 use Dealroadshow\K8S\Framework\Registry\Query\ManifestsQuery;
 
-class AppProcessor
+readonly class AppProcessor
 {
     public function __construct(
         private AppRegistry $appRegistry,

--- a/src/Attribute/Tags.php
+++ b/src/Attribute/Tags.php
@@ -7,7 +7,7 @@ namespace Dealroadshow\K8S\Framework\Attribute;
 use Attribute;
 
 #[Attribute(Attribute::TARGET_CLASS)]
-class Tags
+readonly class Tags
 {
     /**
      * @var string[]

--- a/src/Core/Autoscaling/AbstractHorizontalPodAutoscaler.php
+++ b/src/Core/Autoscaling/AbstractHorizontalPodAutoscaler.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Autoscaling;
 
-use Dealroadshow\K8S\API\Autoscaling\HorizontalPodAutoscaler;
+use Dealroadshow\K8S\Api\Autoscaling\V2\HorizontalPodAutoscaler;
 use Dealroadshow\K8S\Framework\Core\AbstractManifest;
 use Dealroadshow\K8S\Framework\Core\Autoscaling\Configurator\BehaviorConfigurator;
 

--- a/src/Core/Autoscaling/Configurator/BehaviorConfigurator.php
+++ b/src/Core/Autoscaling/Configurator/BehaviorConfigurator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Autoscaling\Configurator;
 
-use Dealroadshow\K8S\Data\HorizontalPodAutoscalerBehavior;
+use Dealroadshow\K8S\Api\Autoscaling\V2\HorizontalPodAutoscalerBehavior;
 
 readonly class BehaviorConfigurator
 {

--- a/src/Core/Autoscaling/Configurator/HPAScalingRulesConfigurator.php
+++ b/src/Core/Autoscaling/Configurator/HPAScalingRulesConfigurator.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Autoscaling\Configurator;
 
-use Dealroadshow\K8S\Data\HPAScalingPolicy;
-use Dealroadshow\K8S\Data\HPAScalingRules;
+use Dealroadshow\K8S\Api\Autoscaling\V2\HPAScalingPolicy;
+use Dealroadshow\K8S\Api\Autoscaling\V2\HPAScalingRules;
 use Dealroadshow\K8S\Framework\Core\Autoscaling\ScalingPolicy;
 use Dealroadshow\K8S\Framework\Core\Autoscaling\SelectPolicy;
 

--- a/src/Core/Autoscaling/Configurator/MetricsConfigurator.php
+++ b/src/Core/Autoscaling/Configurator/MetricsConfigurator.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Autoscaling\Configurator;
 
-use Dealroadshow\K8S\Data\Collection\MetricSpecList;
-use Dealroadshow\K8S\Data\ContainerResourceMetricSource;
-use Dealroadshow\K8S\Data\CrossVersionObjectReference;
-use Dealroadshow\K8S\Data\ExternalMetricSource;
-use Dealroadshow\K8S\Data\MetricIdentifier;
-use Dealroadshow\K8S\Data\MetricSpec;
-use Dealroadshow\K8S\Data\MetricTarget;
-use Dealroadshow\K8S\Data\ObjectMetricSource;
-use Dealroadshow\K8S\Data\PodsMetricSource;
-use Dealroadshow\K8S\Data\ResourceMetricSource;
+use Dealroadshow\K8S\Api\Autoscaling\V2\ContainerResourceMetricSource;
+use Dealroadshow\K8S\Api\Autoscaling\V2\CrossVersionObjectReference;
+use Dealroadshow\K8S\Api\Autoscaling\V2\ExternalMetricSource;
+use Dealroadshow\K8S\Api\Autoscaling\V2\MetricIdentifier;
+use Dealroadshow\K8S\Api\Autoscaling\V2\MetricSpec;
+use Dealroadshow\K8S\Api\Autoscaling\V2\MetricSpecList;
+use Dealroadshow\K8S\Api\Autoscaling\V2\MetricTarget;
+use Dealroadshow\K8S\Api\Autoscaling\V2\ObjectMetricSource;
+use Dealroadshow\K8S\Api\Autoscaling\V2\PodsMetricSource;
+use Dealroadshow\K8S\Api\Autoscaling\V2\ResourceMetricSource;
 use Dealroadshow\K8S\Framework\Core\Autoscaling\Metric\SourceType;
 use Dealroadshow\K8S\Framework\Core\Autoscaling\Metric\TypedMetricTarget;
 use Dealroadshow\K8S\Framework\Core\Autoscaling\Metric\TargetType;

--- a/src/Core/Autoscaling/HorizontalPodAutoscalerInterface.php
+++ b/src/Core/Autoscaling/HorizontalPodAutoscalerInterface.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Autoscaling;
 
-use Dealroadshow\K8S\API\Autoscaling\HorizontalPodAutoscaler;
-use Dealroadshow\K8S\Data\CrossVersionObjectReference;
+use Dealroadshow\K8S\Api\Autoscaling\V2\CrossVersionObjectReference;
+use Dealroadshow\K8S\Api\Autoscaling\V2\HorizontalPodAutoscaler;
 use Dealroadshow\K8S\Framework\Core\Autoscaling\Configurator\BehaviorConfigurator;
 use Dealroadshow\K8S\Framework\Core\Autoscaling\Configurator\MetricsConfigurator;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;

--- a/src/Core/ConfigMap/AbstractConfigMap.php
+++ b/src/Core/ConfigMap/AbstractConfigMap.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\ConfigMap;
 
-use Dealroadshow\K8S\API\ConfigMap;
-use Dealroadshow\K8S\Data\Collection\StringMap;
+use Dealroadshow\K8S\Api\Core\V1\ConfigMap;
+use Dealroadshow\K8S\Collection\StringMap;
 use Dealroadshow\K8S\Framework\Core\AbstractManifest;
 
 abstract class AbstractConfigMap extends AbstractManifest implements ConfigMapInterface

--- a/src/Core/ConfigMap/ConfigMapInterface.php
+++ b/src/Core/ConfigMap/ConfigMapInterface.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\ConfigMap;
 
-use Dealroadshow\K8S\API\ConfigMap;
-use Dealroadshow\K8S\Data\Collection\StringMap;
+use Dealroadshow\K8S\Api\Core\V1\ConfigMap;
+use Dealroadshow\K8S\Collection\StringMap;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;
 
 interface ConfigMapInterface extends ManifestInterface

--- a/src/Core/Container/ContainerInterface.php
+++ b/src/Core/Container/ContainerInterface.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Container;
 
-use Dealroadshow\K8S\Data\Collection\StringList;
-use Dealroadshow\K8S\Data\Container;
+use Dealroadshow\K8S\Api\Core\V1\Container;
+use Dealroadshow\K8S\Collection\StringList;
 use Dealroadshow\K8S\Framework\Core\Container\Env\EnvConfigurator;
 use Dealroadshow\K8S\Framework\Core\Container\Image\Image;
 use Dealroadshow\K8S\Framework\Core\Container\Image\ImagePullPolicy;

--- a/src/Core/Container/ContainerMaker.php
+++ b/src/Core/Container/ContainerMaker.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Container;
 
-use Dealroadshow\K8S\Data\Collection\VolumeList;
-use Dealroadshow\K8S\Data\Container;
+use Dealroadshow\K8S\Api\Core\V1\Container;
+use Dealroadshow\K8S\Api\Core\V1\VolumeList;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\Container\Env\EnvConfigurator;
 use Dealroadshow\K8S\Framework\Core\Container\Image\Image;

--- a/src/Core/Container/ContainerMakerInterface.php
+++ b/src/Core/Container/ContainerMakerInterface.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Container;
 
-use Dealroadshow\K8S\Data\Collection\VolumeList;
-use Dealroadshow\K8S\Data\Container;
+use Dealroadshow\K8S\Api\Core\V1\Container;
+use Dealroadshow\K8S\Api\Core\V1\VolumeList;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 
 interface ContainerMakerInterface

--- a/src/Core/Container/ContainerTrait.php
+++ b/src/Core/Container/ContainerTrait.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Container;
 
-use Dealroadshow\K8S\Data\Collection\StringList;
-use Dealroadshow\K8S\Data\Container;
+use Dealroadshow\K8S\Api\Core\V1\Container;
+use Dealroadshow\K8S\Collection\StringList;
 use Dealroadshow\K8S\Framework\Core\Container\Env\EnvConfigurator;
 use Dealroadshow\K8S\Framework\Core\Container\Image\ImagePullPolicy;
 use Dealroadshow\K8S\Framework\Core\Container\Lifecycle\LifecycleConfigurator;

--- a/src/Core/Container/Env/EnvConfigurator.php
+++ b/src/Core/Container/Env/EnvConfigurator.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Container\Env;
 
-use Dealroadshow\K8S\Data\Collection\EnvFromSourceList;
-use Dealroadshow\K8S\Data\Collection\EnvVarList;
-use Dealroadshow\K8S\Data\ConfigMapEnvSource;
-use Dealroadshow\K8S\Data\ConfigMapKeySelector;
-use Dealroadshow\K8S\Data\EnvFromSource;
-use Dealroadshow\K8S\Data\EnvVar;
-use Dealroadshow\K8S\Data\SecretKeySelector;
+use Dealroadshow\K8S\Api\Core\V1\ConfigMapEnvSource;
+use Dealroadshow\K8S\Api\Core\V1\ConfigMapKeySelector;
+use Dealroadshow\K8S\Api\Core\V1\EnvFromSource;
+use Dealroadshow\K8S\Api\Core\V1\EnvFromSourceList;
+use Dealroadshow\K8S\Api\Core\V1\EnvVar;
+use Dealroadshow\K8S\Api\Core\V1\EnvVarList;
+use Dealroadshow\K8S\Api\Core\V1\SecretKeySelector;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\ConfigMap\ConfigMapInterface;
 use Dealroadshow\K8S\Framework\Core\Container\Resources\ContainerResourcesField;

--- a/src/Core/Container/Lifecycle/Action/ActionConfiguratorTrait.php
+++ b/src/Core/Container/Lifecycle/Action/ActionConfiguratorTrait.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Container\Lifecycle\Action;
 
-use Dealroadshow\K8S\Data\HTTPGetAction;
-use Dealroadshow\K8S\Data\TCPSocketAction;
+use Dealroadshow\K8S\Api\Core\V1\HTTPGetAction;
+use Dealroadshow\K8S\Api\Core\V1\TCPSocketAction;
 
 trait ActionConfiguratorTrait
 {

--- a/src/Core/Container/Lifecycle/Action/HttpGetActionBuilder.php
+++ b/src/Core/Container/Lifecycle/Action/HttpGetActionBuilder.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Container\Lifecycle\Action;
 
-use Dealroadshow\K8S\Data\HTTPGetAction;
-use Dealroadshow\K8S\Data\HTTPHeader;
+use Dealroadshow\K8S\Api\Core\V1\HTTPGetAction;
+use Dealroadshow\K8S\Api\Core\V1\HTTPHeader;
 
 class HttpGetActionBuilder
 {

--- a/src/Core/Container/Lifecycle/Action/LifecycleActionConfigurator.php
+++ b/src/Core/Container/Lifecycle/Action/LifecycleActionConfigurator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Container\Lifecycle\Action;
 
-use Dealroadshow\K8S\Data\LifecycleHandler;
+use Dealroadshow\K8S\Api\Core\V1\LifecycleHandler;
 
 class LifecycleActionConfigurator
 {

--- a/src/Core/Container/Lifecycle/LifecycleConfigurator.php
+++ b/src/Core/Container/Lifecycle/LifecycleConfigurator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Container\Lifecycle;
 
-use Dealroadshow\K8S\Data\Lifecycle;
+use Dealroadshow\K8S\Api\Core\V1\Lifecycle;
 use Dealroadshow\K8S\Framework\Core\Container\Lifecycle\Action\LifecycleActionConfigurator;
 
 class LifecycleConfigurator

--- a/src/Core/Container/Lifecycle/Probes/ProbeActionConfigurator.php
+++ b/src/Core/Container/Lifecycle/Probes/ProbeActionConfigurator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Container\Lifecycle\Probes;
 
-use Dealroadshow\K8S\Data\Probe;
+use Dealroadshow\K8S\Api\Core\V1\Probe;
 use Dealroadshow\K8S\Framework\Core\Container\Lifecycle\Action\ActionConfiguratorTrait;
 
 class ProbeActionConfigurator

--- a/src/Core/Container/Lifecycle/Probes/ProbeConfigurator.php
+++ b/src/Core/Container/Lifecycle/Probes/ProbeConfigurator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Container\Lifecycle\Probes;
 
-use Dealroadshow\K8S\Data\Probe;
+use Dealroadshow\K8S\Api\Core\V1\Probe;
 
 class ProbeConfigurator
 {

--- a/src/Core/Container/Lifecycle/Probes/ProbesConfigurator.php
+++ b/src/Core/Container/Lifecycle/Probes/ProbesConfigurator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Container\Lifecycle\Probes;
 
-use Dealroadshow\K8S\Data\Probe;
+use Dealroadshow\K8S\Api\Core\V1\Probe;
 
 class ProbesConfigurator
 {

--- a/src/Core/Container/Ports/ContainerPortBuilder.php
+++ b/src/Core/Container/Ports/ContainerPortBuilder.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Container\Ports;
 
-use Dealroadshow\K8S\Data\ContainerPort;
+use Dealroadshow\K8S\Api\Core\V1\ContainerPort;
 
 class ContainerPortBuilder
 {

--- a/src/Core/Container/Ports/PortsConfigurator.php
+++ b/src/Core/Container/Ports/PortsConfigurator.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Container\Ports;
 
-use Dealroadshow\K8S\Data\Collection\ContainerPortList;
-use Dealroadshow\K8S\Data\ContainerPort;
+use Dealroadshow\K8S\Api\Core\V1\ContainerPort;
+use Dealroadshow\K8S\Api\Core\V1\ContainerPortList;
 
 class PortsConfigurator
 {

--- a/src/Core/Container/Resources/ContainerResourcesField.php
+++ b/src/Core/Container/Resources/ContainerResourcesField.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Container\Resources;
 
-use Dealroadshow\K8S\Data\ResourceFieldSelector;
+use Dealroadshow\K8S\Api\Core\V1\ResourceFieldSelector;
 
 class ContainerResourcesField
 {

--- a/src/Core/Container/Resources/ResourcesConfigurator.php
+++ b/src/Core/Container/Resources/ResourcesConfigurator.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Container\Resources;
 
-use Dealroadshow\K8S\Data\Collection\StringOrFloatMap;
-use Dealroadshow\K8S\Data\ResourceRequirements;
+use Dealroadshow\K8S\Api\Core\V1\ResourceRequirements;
+use Dealroadshow\K8S\Collection\StringOrFloatMap;
 
 class ResourcesConfigurator implements ContainerResourcesInterface
 {

--- a/src/Core/Container/Security/CapabilitiesConfigurator.php
+++ b/src/Core/Container/Security/CapabilitiesConfigurator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Container\Security;
 
-use Dealroadshow\K8S\Data\Capabilities;
+use Dealroadshow\K8S\Api\Core\V1\Capabilities;
 
 class CapabilitiesConfigurator
 {

--- a/src/Core/Container/Security/SELinuxOptionsConfigurator.php
+++ b/src/Core/Container/Security/SELinuxOptionsConfigurator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Container\Security;
 
-use Dealroadshow\K8S\Data\SELinuxOptions;
+use Dealroadshow\K8S\Api\Core\V1\SELinuxOptions;
 
 class SELinuxOptionsConfigurator
 {

--- a/src/Core/Container/Security/SecurityContextConfigurator.php
+++ b/src/Core/Container/Security/SecurityContextConfigurator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Container\Security;
 
-use Dealroadshow\K8S\Data\SecurityContext;
+use Dealroadshow\K8S\Api\Core\V1\SecurityContext;
 
 class SecurityContextConfigurator
 {

--- a/src/Core/Container/VolumeMount/VolumeMountBuilder.php
+++ b/src/Core/Container/VolumeMount/VolumeMountBuilder.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Container\VolumeMount;
 
-use Dealroadshow\K8S\Data\VolumeMount;
+use Dealroadshow\K8S\Api\Core\V1\VolumeMount;
 
 class VolumeMountBuilder
 {

--- a/src/Core/Container/VolumeMount/VolumeMountsConfigurator.php
+++ b/src/Core/Container/VolumeMount/VolumeMountsConfigurator.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Container\VolumeMount;
 
-use Dealroadshow\K8S\Data\Collection\VolumeList;
-use Dealroadshow\K8S\Data\Collection\VolumeMountList;
-use Dealroadshow\K8S\Data\VolumeMount;
+use Dealroadshow\K8S\Api\Core\V1\VolumeList;
+use Dealroadshow\K8S\Api\Core\V1\VolumeMount;
+use Dealroadshow\K8S\Api\Core\V1\VolumeMountList;
 use Dealroadshow\K8S\Framework\Core\Pod\Volume\VolumesMap;
 
 class VolumeMountsConfigurator

--- a/src/Core/CronJob/AbstractCronJob.php
+++ b/src/Core/CronJob/AbstractCronJob.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\CronJob;
 
-use Dealroadshow\K8S\API\Batch\CronJob;
+use Dealroadshow\K8S\Api\Batch\V1\CronJob;
 use Dealroadshow\K8S\Framework\Core\Job\AbstractJob;
 use Dealroadshow\K8S\Framework\Core\Job\JobInterface;
 use Dealroadshow\K8S\Framework\Core\Pod\PriorityClass\PriorityClassConfigurator;

--- a/src/Core/CronJob/CronJobInterface.php
+++ b/src/Core/CronJob/CronJobInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\CronJob;
 
-use Dealroadshow\K8S\API\Batch\CronJob;
+use Dealroadshow\K8S\Api\Batch\V1\CronJob;
 use Dealroadshow\K8S\Framework\Core\Job\JobInterface;
 
 interface CronJobInterface extends JobInterface

--- a/src/Core/Deployment/AbstractDeployment.php
+++ b/src/Core/Deployment/AbstractDeployment.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Deployment;
 
-use Dealroadshow\K8S\API\Apps\Deployment;
-use Dealroadshow\K8S\Data\Collection\StringMap;
-use Dealroadshow\K8S\Data\PodSpec;
+use Dealroadshow\K8S\Api\Apps\V1\Deployment;
+use Dealroadshow\K8S\Api\Core\V1\PodSpec;
+use Dealroadshow\K8S\Collection\StringMap;
 use Dealroadshow\K8S\Framework\Core\AbstractManifest;
 use Dealroadshow\K8S\Framework\Core\LabelSelector\SelectorConfigurator;
 use Dealroadshow\K8S\Framework\Core\ManifestReference;

--- a/src/Core/Deployment/DeploymentInterface.php
+++ b/src/Core/Deployment/DeploymentInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Deployment;
 
-use Dealroadshow\K8S\API\Apps\Deployment;
+use Dealroadshow\K8S\Api\Apps\V1\Deployment;
 use Dealroadshow\K8S\Framework\Core\LabelSelector\SelectorConfigurator;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;
 use Dealroadshow\K8S\Framework\Core\Pod\PodTemplateSpecInterface;

--- a/src/Core/Deployment/StrategyConfigurator.php
+++ b/src/Core/Deployment/StrategyConfigurator.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Deployment;
 
-use Dealroadshow\K8S\Data\DeploymentStrategy;
+use Dealroadshow\K8S\Api\Apps\V1\DeploymentStrategy;
 use Dealroadshow\K8S\Framework\Core\Deployment\ValueObject\NumberOrPercents;
 
-class StrategyConfigurator
+readonly class StrategyConfigurator
 {
     private const TYPE_ROLLING_UPDATE = 'RollingUpdate';
     private const TYPE_RECREATE = 'Recreate';

--- a/src/Core/Ingress/AbstractIngress.php
+++ b/src/Core/Ingress/AbstractIngress.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Ingress;
 
-use Dealroadshow\K8S\API\Networking\Ingress;
+use Dealroadshow\K8S\Api\Networking\V1\Ingress;
 use Dealroadshow\K8S\Framework\Core\AbstractManifest;
 use Dealroadshow\K8S\Framework\Core\Ingress\Configurator\IngressBackendConfigurator;
 

--- a/src/Core/Ingress/Configurator/HttpIngressPathConfigurator.php
+++ b/src/Core/Ingress/Configurator/HttpIngressPathConfigurator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Ingress\Configurator;
 
-use Dealroadshow\K8S\Data\HTTPIngressPath;
+use Dealroadshow\K8S\Api\Networking\V1\HTTPIngressPath;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Registry\AppRegistry;
 use Dealroadshow\K8S\Framework\Util\ManifestReferencesService;

--- a/src/Core/Ingress/Configurator/IngressBackendConfigurator.php
+++ b/src/Core/Ingress/Configurator/IngressBackendConfigurator.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Ingress\Configurator;
 
-use Dealroadshow\K8S\Data\IngressBackend;
-use Dealroadshow\K8S\Data\IngressServiceBackend;
+use Dealroadshow\K8S\Api\Networking\V1\IngressBackend;
+use Dealroadshow\K8S\Api\Networking\V1\IngressServiceBackend;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\ManifestReference;
 use Dealroadshow\K8S\Framework\Registry\AppRegistry;

--- a/src/Core/Ingress/Configurator/IngressRuleConfigurator.php
+++ b/src/Core/Ingress/Configurator/IngressRuleConfigurator.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Dealroadshow\K8S\Framework\Core\Ingress\Configurator;
 
 use Composer\Semver\Comparator;
-use Dealroadshow\K8S\Data\HTTPIngressPath;
-use Dealroadshow\K8S\Data\IngressRule;
+use Dealroadshow\K8S\Api\Networking\V1\HTTPIngressPath;
+use Dealroadshow\K8S\Api\Networking\V1\IngressRule;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\Ingress\Http\PathType;
 use Dealroadshow\K8S\Framework\Registry\AppRegistry;
@@ -61,8 +61,7 @@ readonly class IngressRuleConfigurator
             return new HTTPIngressPath($pathType->toString());
         }
 
-        $path = new HTTPIngressPath();
-        $path->setPathType($pathType->toString());
+        $path = new HTTPIngressPath($pathType->toString());
 
         return $path;
     }

--- a/src/Core/Ingress/Configurator/IngressRulesConfigurator.php
+++ b/src/Core/Ingress/Configurator/IngressRulesConfigurator.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Ingress\Configurator;
 
-use Dealroadshow\K8S\Data\Collection\IngressRuleList;
-use Dealroadshow\K8S\Data\IngressRule;
+use Dealroadshow\K8S\Api\Networking\V1\IngressRule;
+use Dealroadshow\K8S\Api\Networking\V1\IngressRuleList;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Registry\AppRegistry;
 use Dealroadshow\K8S\Framework\Util\ManifestReferencesService;

--- a/src/Core/Ingress/IngressInterface.php
+++ b/src/Core/Ingress/IngressInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Ingress;
 
-use Dealroadshow\K8S\API\Networking\Ingress;
+use Dealroadshow\K8S\Api\Networking\V1\Ingress;
 use Dealroadshow\K8S\Framework\Core\Ingress\Configurator\IngressBackendConfigurator;
 use Dealroadshow\K8S\Framework\Core\Ingress\Configurator\IngressRulesConfigurator;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;

--- a/src/Core/Job/AbstractJob.php
+++ b/src/Core/Job/AbstractJob.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Job;
 
-use Dealroadshow\K8S\API\Batch\Job;
-use Dealroadshow\K8S\Data\Collection\StringMap;
-use Dealroadshow\K8S\Data\PodSpec;
+use Dealroadshow\K8S\Api\Batch\V1\Job;
+use Dealroadshow\K8S\Api\Core\V1\PodSpec;
+use Dealroadshow\K8S\Collection\StringMap;
 use Dealroadshow\K8S\Framework\Core\AbstractManifest;
 use Dealroadshow\K8S\Framework\Core\LabelSelector\SelectorConfigurator;
 use Dealroadshow\K8S\Framework\Core\ManifestReference;

--- a/src/Core/Job/JobInterface.php
+++ b/src/Core/Job/JobInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Job;
 
-use Dealroadshow\K8S\API\Batch\Job;
+use Dealroadshow\K8S\Api\Batch\V1\Job;
 use Dealroadshow\K8S\Framework\Core\LabelSelector\SelectorConfigurator;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;
 use Dealroadshow\K8S\Framework\Core\Pod\PodTemplateSpecInterface;

--- a/src/Core/Job/JobSpecProcessor.php
+++ b/src/Core/Job/JobSpecProcessor.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Job;
 
-use Dealroadshow\K8S\Data\JobSpec;
+use Dealroadshow\K8S\Api\Batch\V1\JobSpec;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\Pod\PodTemplateSpecProcessor;
 

--- a/src/Core/LabelSelector/LabelSelectorExpression.php
+++ b/src/Core/LabelSelector/LabelSelectorExpression.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\LabelSelector;
 
-use Dealroadshow\K8S\Data\LabelSelectorRequirement;
+use Dealroadshow\K8S\Apimachinery\Pkg\Apis\Meta\V1\LabelSelectorRequirement;
 
 class LabelSelectorExpression
 {

--- a/src/Core/LabelSelector/SelectorConfigurator.php
+++ b/src/Core/LabelSelector/SelectorConfigurator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\LabelSelector;
 
-use Dealroadshow\K8S\Data\LabelSelector;
+use Dealroadshow\K8S\Apimachinery\Pkg\Apis\Meta\V1\LabelSelector;
 
 class SelectorConfigurator
 {

--- a/src/Core/MetadataConfigurator.php
+++ b/src/Core/MetadataConfigurator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core;
 
-use Dealroadshow\K8S\Data\Collection\StringMap;
+use Dealroadshow\K8S\Collection\StringMap;
 
 class MetadataConfigurator
 {

--- a/src/Core/Persistence/AbstractPersistentVolumeClaim.php
+++ b/src/Core/Persistence/AbstractPersistentVolumeClaim.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Persistence;
 
-use Dealroadshow\K8S\API\PersistentVolume;
+use Dealroadshow\K8S\Api\Core\V1\PersistentVolume;
 use Dealroadshow\K8S\Framework\Core\AbstractManifest;
 use Dealroadshow\K8S\Framework\Core\LabelSelector\SelectorConfigurator;
 use Dealroadshow\K8S\Framework\Core\ManifestReference;

--- a/src/Core/Persistence/PvcResourcesConfigurator.php
+++ b/src/Core/Persistence/PvcResourcesConfigurator.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Persistence;
 
-use Dealroadshow\K8S\Data\ResourceRequirements;
-use Dealroadshow\K8S\Data\VolumeResourceRequirements;
+use Dealroadshow\K8S\Api\Core\V1\ResourceRequirements;
+use Dealroadshow\K8S\Api\Core\V1\VolumeResourceRequirements;
 use Dealroadshow\K8S\Framework\Core\Container\Resources\ContainerResource;
 use Dealroadshow\K8S\Framework\Core\Container\Resources\Memory;
 

--- a/src/Core/Persistence/VolumeMode.php
+++ b/src/Core/Persistence/VolumeMode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Persistence;
 
-final class VolumeMode
+final readonly class VolumeMode
 {
     private const FILESYSTEM = 'Filesystem';
     private const BLOCK = 'Block';

--- a/src/Core/Pod/Affinity/AffinityConfigurator.php
+++ b/src/Core/Pod/Affinity/AffinityConfigurator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Pod\Affinity;
 
-use Dealroadshow\K8S\Data\Affinity;
+use Dealroadshow\K8S\Api\Core\V1\Affinity;
 use Dealroadshow\K8S\Framework\Core\Pod\Affinity\Node\NodeAffinityBuilder;
 use Dealroadshow\K8S\Framework\Core\Pod\Affinity\Pod\PodAffinityBuilder;
 

--- a/src/Core/Pod/Affinity/Node/NodeAffinityBuilder.php
+++ b/src/Core/Pod/Affinity/Node/NodeAffinityBuilder.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Pod\Affinity\Node;
 
-use Dealroadshow\K8S\Data\NodeAffinity;
-use Dealroadshow\K8S\Data\NodeSelectorTerm;
-use Dealroadshow\K8S\Data\PreferredSchedulingTerm;
+use Dealroadshow\K8S\Api\Core\V1\NodeAffinity;
+use Dealroadshow\K8S\Api\Core\V1\NodeSelectorTerm;
+use Dealroadshow\K8S\Api\Core\V1\PreferredSchedulingTerm;
 use Dealroadshow\K8S\Framework\Core\Pod\Affinity\NodeAffinityExpression;
 
 class NodeAffinityBuilder

--- a/src/Core/Pod/Affinity/NodeAffinityExpression.php
+++ b/src/Core/Pod/Affinity/NodeAffinityExpression.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Pod\Affinity;
 
-use Dealroadshow\K8S\Data\NodeSelectorRequirement;
+use Dealroadshow\K8S\Api\Core\V1\NodeSelectorRequirement;
 use Dealroadshow\K8S\Framework\Core\LabelSelector\Operator;
 
 class NodeAffinityExpression extends PodAffinityExpression

--- a/src/Core/Pod/Affinity/Pod/PodAffinityBuilder.php
+++ b/src/Core/Pod/Affinity/Pod/PodAffinityBuilder.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Pod\Affinity\Pod;
 
-use Dealroadshow\K8S\Data\Collection\PodAffinityTermList;
-use Dealroadshow\K8S\Data\Collection\WeightedPodAffinityTermList;
-use Dealroadshow\K8S\Data\PodAffinityTerm;
-use Dealroadshow\K8S\Data\WeightedPodAffinityTerm;
+use Dealroadshow\K8S\Api\Core\V1\PodAffinityTerm;
+use Dealroadshow\K8S\Api\Core\V1\PodAffinityTermList;
+use Dealroadshow\K8S\Api\Core\V1\WeightedPodAffinityTerm;
+use Dealroadshow\K8S\Api\Core\V1\WeightedPodAffinityTermList;
 use Dealroadshow\K8S\Framework\Core\Pod\Affinity\PodAffinityExpression;
 
 class PodAffinityBuilder

--- a/src/Core/Pod/ImagePullSecrets/ImagePullSecretsConfigurator.php
+++ b/src/Core/Pod/ImagePullSecrets/ImagePullSecretsConfigurator.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Pod\ImagePullSecrets;
 
-use Dealroadshow\K8S\Data\Collection\LocalObjectReferenceList;
-use Dealroadshow\K8S\Data\LocalObjectReference;
+use Dealroadshow\K8S\Api\Core\V1\LocalObjectReference;
+use Dealroadshow\K8S\Api\Core\V1\LocalObjectReferenceList;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 
 class ImagePullSecretsConfigurator

--- a/src/Core/Pod/PodField.php
+++ b/src/Core/Pod/PodField.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Pod;
 
-use Dealroadshow\K8S\Data\ObjectFieldSelector;
+use Dealroadshow\K8S\Api\Core\V1\ObjectFieldSelector;
 
 class PodField
 {

--- a/src/Core/Pod/PodSpecInterface.php
+++ b/src/Core/Pod/PodSpecInterface.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Pod;
 
-use Dealroadshow\K8S\Data\Collection\StringMap;
-use Dealroadshow\K8S\Data\PodSpec;
+use Dealroadshow\K8S\Api\Core\V1\PodSpec;
+use Dealroadshow\K8S\Collection\StringMap;
 use Dealroadshow\K8S\Framework\Core\Container\ContainerInterface;
 use Dealroadshow\K8S\Framework\Core\ManifestReference;
 use Dealroadshow\K8S\Framework\Core\Pod\Affinity\AffinityConfigurator;

--- a/src/Core/Pod/PodSpecProcessor.php
+++ b/src/Core/Pod/PodSpecProcessor.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Pod;
 
-use Dealroadshow\K8S\Data\PodSpec;
+use Dealroadshow\K8S\Api\Core\V1\PodSpec;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\Container\ContainerInterface;
 use Dealroadshow\K8S\Framework\Core\Container\ContainerMakerInterface;

--- a/src/Core/Pod/PodTemplateSpecProcessor.php
+++ b/src/Core/Pod/PodTemplateSpecProcessor.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Pod;
 
-use Dealroadshow\K8S\Data\PodTemplateSpec;
+use Dealroadshow\K8S\Api\Core\V1\PodTemplateSpec;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\MetadataConfigurator;
 use Dealroadshow\K8S\Framework\Event\PodTemplateSpecGeneratedEvent;

--- a/src/Core/Pod/PriorityClass/PriorityClassConfigurator.php
+++ b/src/Core/Pod/PriorityClass/PriorityClassConfigurator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Pod\PriorityClass;
 
-use Dealroadshow\K8S\Data\PodSpec;
+use Dealroadshow\K8S\Api\Core\V1\PodSpec;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\PriorityClass\PriorityClassInterface;
 use Dealroadshow\K8S\Framework\Registry\AppRegistry;
@@ -13,8 +13,11 @@ class PriorityClassConfigurator
 {
     private bool $locked = false;
 
-    public function __construct(private PodSpec $spec, private AppInterface $app, private AppRegistry $appRegistry)
-    {
+    public function __construct(
+        private readonly PodSpec $spec,
+        private readonly AppInterface $app,
+        private readonly AppRegistry $appRegistry
+    ) {
     }
 
     public function fromPHPClass(string $phpClassName): void

--- a/src/Core/Pod/Toleration/TolerationsConfigurator.php
+++ b/src/Core/Pod/Toleration/TolerationsConfigurator.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Pod\Toleration;
 
-use Dealroadshow\K8S\Data\Collection\TolerationList;
-use Dealroadshow\K8S\Data\Toleration;
+use Dealroadshow\K8S\Api\Core\V1\Toleration;
+use Dealroadshow\K8S\Api\Core\V1\TolerationList;
 
-class TolerationsConfigurator
+readonly class TolerationsConfigurator
 {
     public function __construct(private TolerationList $tolerations)
     {

--- a/src/Core/Pod/Topology/TopologySpreadConstraintConfigurator.php
+++ b/src/Core/Pod/Topology/TopologySpreadConstraintConfigurator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Pod\Topology;
 
-use Dealroadshow\K8S\Data\TopologySpreadConstraint;
+use Dealroadshow\K8S\Api\Core\V1\TopologySpreadConstraint;
 use Dealroadshow\K8S\Framework\Core\LabelSelector\SelectorConfigurator;
 
 readonly class TopologySpreadConstraintConfigurator

--- a/src/Core/Pod/Topology/TopologySpreadConstraintsConfigurator.php
+++ b/src/Core/Pod/Topology/TopologySpreadConstraintsConfigurator.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Pod\Topology;
 
-use Dealroadshow\K8S\Data\Collection\TopologySpreadConstraintList;
-use Dealroadshow\K8S\Data\TopologySpreadConstraint;
+use Dealroadshow\K8S\Api\Core\V1\TopologySpreadConstraint;
+use Dealroadshow\K8S\Api\Core\V1\TopologySpreadConstraintList;
 
 readonly class TopologySpreadConstraintsConfigurator
 {

--- a/src/Core/Pod/Volume/Builder/AbstractVolumeBuilder.php
+++ b/src/Core/Pod/Volume/Builder/AbstractVolumeBuilder.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Pod\Volume\Builder;
 
-use Dealroadshow\K8S\Data\Volume;
+use Dealroadshow\K8S\Api\Core\V1\Volume;
 
 abstract class AbstractVolumeBuilder implements VolumeBuilderInterface
 {

--- a/src/Core/Pod/Volume/Builder/ConfigMapVolumeBuilder.php
+++ b/src/Core/Pod/Volume/Builder/ConfigMapVolumeBuilder.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Pod\Volume\Builder;
 
-use Dealroadshow\K8S\Data\ConfigMapVolumeSource;
-use Dealroadshow\K8S\Data\KeyToPath;
-use Dealroadshow\K8S\Data\Volume;
+use Dealroadshow\K8S\Api\Core\V1\ConfigMapVolumeSource;
+use Dealroadshow\K8S\Api\Core\V1\KeyToPath;
+use Dealroadshow\K8S\Api\Core\V1\Volume;
 
 class ConfigMapVolumeBuilder extends AbstractVolumeBuilder
 {

--- a/src/Core/Pod/Volume/Builder/DownwardAPIVolumeBuilder.php
+++ b/src/Core/Pod/Volume/Builder/DownwardAPIVolumeBuilder.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Pod\Volume\Builder;
 
-use Dealroadshow\K8S\Data\DownwardAPIVolumeFile;
-use Dealroadshow\K8S\Data\DownwardAPIVolumeSource;
-use Dealroadshow\K8S\Data\Volume;
+use Dealroadshow\K8S\Api\Core\V1\DownwardAPIVolumeFile;
+use Dealroadshow\K8S\Api\Core\V1\DownwardAPIVolumeSource;
+use Dealroadshow\K8S\Api\Core\V1\Volume;
 use Dealroadshow\K8S\Framework\Core\Container\Resources\ContainerResourcesField;
 use Dealroadshow\K8S\Framework\Core\Pod\PodField;
 

--- a/src/Core/Pod/Volume/Builder/EmptyDirVolumeBuilder.php
+++ b/src/Core/Pod/Volume/Builder/EmptyDirVolumeBuilder.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Pod\Volume\Builder;
 
-use Dealroadshow\K8S\Data\EmptyDirVolumeSource;
-use Dealroadshow\K8S\Data\Volume;
+use Dealroadshow\K8S\Api\Core\V1\EmptyDirVolumeSource;
+use Dealroadshow\K8S\Api\Core\V1\Volume;
 use Dealroadshow\K8S\Framework\Core\Container\Resources\Memory;
 
 class EmptyDirVolumeBuilder extends AbstractVolumeBuilder

--- a/src/Core/Pod/Volume/Builder/PVCVolumeBuilder.php
+++ b/src/Core/Pod/Volume/Builder/PVCVolumeBuilder.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Pod\Volume\Builder;
 
-use Dealroadshow\K8S\Data\PersistentVolumeClaimVolumeSource;
-use Dealroadshow\K8S\Data\Volume;
+use Dealroadshow\K8S\Api\Core\V1\PersistentVolumeClaimVolumeSource;
+use Dealroadshow\K8S\Api\Core\V1\Volume;
 
 class PVCVolumeBuilder extends AbstractVolumeBuilder
 {

--- a/src/Core/Pod/Volume/Builder/SecretVolumeBuilder.php
+++ b/src/Core/Pod/Volume/Builder/SecretVolumeBuilder.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Pod\Volume\Builder;
 
-use Dealroadshow\K8S\Data\KeyToPath;
-use Dealroadshow\K8S\Data\SecretVolumeSource;
-use Dealroadshow\K8S\Data\Volume;
+use Dealroadshow\K8S\Api\Core\V1\KeyToPath;
+use Dealroadshow\K8S\Api\Core\V1\SecretVolumeSource;
+use Dealroadshow\K8S\Api\Core\V1\Volume;
 
 class SecretVolumeBuilder extends AbstractVolumeBuilder
 {

--- a/src/Core/Pod/Volume/Builder/VolumeBuilderInterface.php
+++ b/src/Core/Pod/Volume/Builder/VolumeBuilderInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Pod\Volume\Builder;
 
-use Dealroadshow\K8S\Data\Volume;
+use Dealroadshow\K8S\Api\Core\V1\Volume;
 
 interface VolumeBuilderInterface
 {

--- a/src/Core/Pod/Volume/VolumesConfigurator.php
+++ b/src/Core/Pod/Volume/VolumesConfigurator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Pod\Volume;
 
+use Dealroadshow\K8S\Api\Core\V1\Volume;
 use Dealroadshow\K8S\Api\Core\V1\VolumeList;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\Pod\Volume\Builder\ConfigMapVolumeBuilder;

--- a/src/Core/Pod/Volume/VolumesConfigurator.php
+++ b/src/Core/Pod/Volume/VolumesConfigurator.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Pod\Volume;
 
-use Dealroadshow\K8S\Data\Collection\VolumeList;
-use Dealroadshow\K8S\Data\Volume;
+use Dealroadshow\K8S\Api\Core\V1\VolumeList;
 use Dealroadshow\K8S\Framework\App\AppInterface;
-use Dealroadshow\K8S\Framework\Core\ManifestReference;
 use Dealroadshow\K8S\Framework\Core\Pod\Volume\Builder\ConfigMapVolumeBuilder;
 use Dealroadshow\K8S\Framework\Core\Pod\Volume\Builder\DownwardAPIVolumeBuilder;
 use Dealroadshow\K8S\Framework\Core\Pod\Volume\Builder\EmptyDirVolumeBuilder;
@@ -16,10 +14,13 @@ use Dealroadshow\K8S\Framework\Core\Pod\Volume\Builder\SecretVolumeBuilder;
 use Dealroadshow\K8S\Framework\Core\Pod\Volume\Builder\VolumeBuilderInterface;
 use Dealroadshow\K8S\Framework\Registry\AppRegistry;
 
-class VolumesConfigurator
+readonly class VolumesConfigurator
 {
-    public function __construct(private VolumeList $volumes, private AppInterface $app, private AppRegistry $registry)
-    {
+    public function __construct(
+        private VolumeList $volumes,
+        private AppInterface $app,
+        private AppRegistry $registry
+    ) {
     }
 
     public function fromConfigMap(string $volumeName, string $configMapClass): ConfigMapVolumeBuilder

--- a/src/Core/Pod/Volume/VolumesMap.php
+++ b/src/Core/Pod/Volume/VolumesMap.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Pod\Volume;
 
-use Dealroadshow\K8S\Data\Collection\VolumeList;
-use Dealroadshow\K8S\Data\Volume;
+use Dealroadshow\K8S\Api\Core\V1\Volume;
+use Dealroadshow\K8S\Api\Core\V1\VolumeList;
 
 class VolumesMap
 {

--- a/src/Core/PriorityClass/AbstractPriorityClass.php
+++ b/src/Core/PriorityClass/AbstractPriorityClass.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\PriorityClass;
 
-use Dealroadshow\K8S\API\Scheduling\PriorityClass;
+use Dealroadshow\K8S\Api\Scheduling\V1\PriorityClass;
 use Dealroadshow\K8S\Framework\Core\AbstractManifest;
 
 abstract class AbstractPriorityClass extends AbstractManifest implements PriorityClassInterface

--- a/src/Core/Rbac/AbstractClusterRole.php
+++ b/src/Core/Rbac/AbstractClusterRole.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Rbac;
 
-use Dealroadshow\K8S\API\Rbac\ClusterRole;
+use Dealroadshow\K8S\Api\Rbac\V1\ClusterRole;
 use Dealroadshow\K8S\Framework\Core\AbstractManifest;
 use Dealroadshow\K8S\Framework\Core\Rbac\Configurator\AggregationRuleConfigurator;
 

--- a/src/Core/Rbac/AbstractClusterRoleBinding.php
+++ b/src/Core/Rbac/AbstractClusterRoleBinding.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Rbac;
 
-use Dealroadshow\K8S\API\Rbac\ClusterRoleBinding;
+use Dealroadshow\K8S\Api\Rbac\V1\ClusterRoleBinding;
 use Dealroadshow\K8S\Framework\Core\AbstractManifest;
 
 abstract class AbstractClusterRoleBinding extends AbstractManifest implements ClusterRoleBindingInterface

--- a/src/Core/Rbac/AbstractRole.php
+++ b/src/Core/Rbac/AbstractRole.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Rbac;
 
-use Dealroadshow\K8S\API\Rbac\Role;
+use Dealroadshow\K8S\Api\Rbac\V1\Role;
 use Dealroadshow\K8S\Framework\Core\AbstractManifest;
 
 abstract class AbstractRole extends AbstractManifest implements RoleInterface

--- a/src/Core/Rbac/AbstractRoleBinding.php
+++ b/src/Core/Rbac/AbstractRoleBinding.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Rbac;
 
-use Dealroadshow\K8S\API\Rbac\RoleBinding;
+use Dealroadshow\K8S\Api\Rbac\V1\RoleBinding;
 use Dealroadshow\K8S\Framework\Core\AbstractManifest;
 
 abstract class AbstractRoleBinding extends AbstractManifest implements RoleBindingInterface

--- a/src/Core/Rbac/ClusterRoleInterface.php
+++ b/src/Core/Rbac/ClusterRoleInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Rbac;
 
-use Dealroadshow\K8S\API\Rbac\ClusterRole;
+use Dealroadshow\K8S\Api\Rbac\V1\ClusterRole;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;
 use Dealroadshow\K8S\Framework\Core\Rbac\Configurator\AggregationRuleConfigurator;
 use Dealroadshow\K8S\Framework\Core\Rbac\Configurator\PolicyRulesConfigurator;

--- a/src/Core/Rbac/Configurator/AggregationRuleConfigurator.php
+++ b/src/Core/Rbac/Configurator/AggregationRuleConfigurator.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Rbac\Configurator;
 
-use Dealroadshow\K8S\Data\AggregationRule;
-use Dealroadshow\K8S\Data\LabelSelector;
+use Dealroadshow\K8S\Api\Rbac\V1\AggregationRule;
+use Dealroadshow\K8S\Apimachinery\Pkg\Apis\Meta\V1\LabelSelector;
 use Dealroadshow\K8S\Framework\Core\LabelSelector\SelectorConfigurator;
 
 readonly class AggregationRuleConfigurator

--- a/src/Core/Rbac/Configurator/Binding/RoleRefConfigurator.php
+++ b/src/Core/Rbac/Configurator/Binding/RoleRefConfigurator.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Rbac\Configurator\Binding;
 
-use Dealroadshow\K8S\API\Rbac\ClusterRole;
-use Dealroadshow\K8S\API\Rbac\Role;
-use Dealroadshow\K8S\Data\RoleRef;
+use Dealroadshow\K8S\Api\Rbac\V1\ClusterRole;
+use Dealroadshow\K8S\Api\Rbac\V1\Role;
+use Dealroadshow\K8S\Api\Rbac\V1\RoleRef;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Registry\AppRegistry;
 

--- a/src/Core/Rbac/Configurator/PolicyRuleConfigurator.php
+++ b/src/Core/Rbac/Configurator/PolicyRuleConfigurator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Rbac\Configurator;
 
-use Dealroadshow\K8S\Data\PolicyRule;
+use Dealroadshow\K8S\Api\Rbac\V1\PolicyRule;
 use Dealroadshow\K8S\Framework\Core\Rbac\Verb;
 
 readonly class PolicyRuleConfigurator

--- a/src/Core/Rbac/Configurator/PolicyRulesConfigurator.php
+++ b/src/Core/Rbac/Configurator/PolicyRulesConfigurator.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Rbac\Configurator;
 
-use Dealroadshow\K8S\Data\Collection\PolicyRuleList;
-use Dealroadshow\K8S\Data\PolicyRule;
-use Dealroadshow\K8S\Framework\Core\Rbac\Configurator\PolicyRuleConfigurator;
+use Dealroadshow\K8S\Api\Rbac\V1\PolicyRule;
+use Dealroadshow\K8S\Api\Rbac\V1\PolicyRuleList;
 
 readonly class PolicyRulesConfigurator
 {

--- a/src/Core/Rbac/RoleInterface.php
+++ b/src/Core/Rbac/RoleInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Rbac;
 
-use Dealroadshow\K8S\API\Rbac\Role;
+use Dealroadshow\K8S\Api\Rbac\V1\Role;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;
 use Dealroadshow\K8S\Framework\Core\Rbac\Configurator\PolicyRulesConfigurator;
 

--- a/src/Core/Secret/AbstractBasicAuthSecret.php
+++ b/src/Core/Secret/AbstractBasicAuthSecret.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Secret;
 
-use Dealroadshow\K8S\Data\Collection\StringMap;
+use Dealroadshow\K8S\Collection\StringMap;
 
 abstract class AbstractBasicAuthSecret extends AbstractSecret
 {

--- a/src/Core/Secret/AbstractDockerConfigSecret.php
+++ b/src/Core/Secret/AbstractDockerConfigSecret.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Secret;
 
-use Dealroadshow\K8S\Data\Collection\StringMap;
+use Dealroadshow\K8S\Collection\StringMap;
 use InvalidArgumentException;
 
 abstract class AbstractDockerConfigSecret extends AbstractSecret

--- a/src/Core/Secret/AbstractSecret.php
+++ b/src/Core/Secret/AbstractSecret.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Secret;
 
-use Dealroadshow\K8S\API\Secret;
-use Dealroadshow\K8S\Data\Collection\StringMap;
+use Dealroadshow\K8S\Api\Core\V1\Secret;
+use Dealroadshow\K8S\Collection\StringMap;
 use Dealroadshow\K8S\Framework\Core\AbstractManifest;
 
 abstract class AbstractSecret extends AbstractManifest implements SecretInterface

--- a/src/Core/Secret/AbstractServiceAccountSecret.php
+++ b/src/Core/Secret/AbstractServiceAccountSecret.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Secret;
 
-use Dealroadshow\K8S\Data\Collection\StringMap;
+use Dealroadshow\K8S\Collection\StringMap;
 use Dealroadshow\K8S\Framework\Core\MetadataConfigurator;
 
 abstract class AbstractServiceAccountSecret extends AbstractSecret

--- a/src/Core/Secret/DockerAuth.php
+++ b/src/Core/Secret/DockerAuth.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Secret;
 
-class DockerAuth
+readonly class DockerAuth
 {
-    public function __construct(public readonly string $host, public readonly string $username, public readonly string $password, public readonly string|null $email = null)
-    {
+    public function __construct(
+        public string $host,
+        public string $username,
+        public string $password,
+        public string|null $email = null
+    ) {
     }
 }

--- a/src/Core/Secret/SecretInterface.php
+++ b/src/Core/Secret/SecretInterface.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Secret;
 
-use Dealroadshow\K8S\API\Secret;
-use Dealroadshow\K8S\Data\Collection\StringMap;
+use Dealroadshow\K8S\Api\Core\V1\Secret;
+use Dealroadshow\K8S\Collection\StringMap;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;
 
 interface SecretInterface extends ManifestInterface

--- a/src/Core/Service/AbstractService.php
+++ b/src/Core/Service/AbstractService.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Service;
 
-use Dealroadshow\K8S\API\Service;
-use Dealroadshow\K8S\Data\Collection\StringMap;
+use Dealroadshow\K8S\Api\Core\V1\Service;
+use Dealroadshow\K8S\Collection\StringMap;
 use Dealroadshow\K8S\Framework\Core\AbstractManifest;
 use Dealroadshow\K8S\Framework\Core\Service\Configurator\ServicePortsConfigurator;
 use Dealroadshow\K8S\Framework\Core\Service\Configurator\ServiceTypeConfigurator;

--- a/src/Core/Service/Configurator/ServicePortConfigurator.php
+++ b/src/Core/Service/Configurator/ServicePortConfigurator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Service\Configurator;
 
-use Dealroadshow\K8S\Data\ServicePort;
+use Dealroadshow\K8S\Api\Core\V1\ServicePort;
 use Dealroadshow\K8S\Framework\Core\Service\IPProtocol;
 
 class ServicePortConfigurator

--- a/src/Core/Service/Configurator/ServicePortsConfigurator.php
+++ b/src/Core/Service/Configurator/ServicePortsConfigurator.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Service\Configurator;
 
-use Dealroadshow\K8S\Data\Collection\ServicePortList;
-use Dealroadshow\K8S\Data\ServicePort;
+use Dealroadshow\K8S\Api\Core\V1\ServicePort;
+use Dealroadshow\K8S\Api\Core\V1\ServicePortList;
 
 class ServicePortsConfigurator
 {

--- a/src/Core/Service/Configurator/ServiceTypeConfigurator.php
+++ b/src/Core/Service/Configurator/ServiceTypeConfigurator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Service\Configurator;
 
-use Dealroadshow\K8S\API\Service;
+use Dealroadshow\K8S\Api\Core\V1\Service;
 
 class ServiceTypeConfigurator
 {

--- a/src/Core/Service/ServiceInterface.php
+++ b/src/Core/Service/ServiceInterface.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\Service;
 
-use Dealroadshow\K8S\API\Service;
-use Dealroadshow\K8S\Data\Collection\StringMap;
+use Dealroadshow\K8S\Api\Core\V1\Service;
+use Dealroadshow\K8S\Collection\StringMap;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;
 use Dealroadshow\K8S\Framework\Core\Service\Configurator\ServicePortsConfigurator;
 use Dealroadshow\K8S\Framework\Core\Service\Configurator\ServiceTypeConfigurator;

--- a/src/Core/ServiceAccount/AbstractServiceAccount.php
+++ b/src/Core/ServiceAccount/AbstractServiceAccount.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\ServiceAccount;
 
-use Dealroadshow\K8S\API\ServiceAccount;
+use Dealroadshow\K8S\Api\Core\V1\ServiceAccount;
 use Dealroadshow\K8S\Framework\Core\AbstractManifest;
 use Dealroadshow\K8S\Framework\Core\ServiceAccount\Configurator\ImagePullSecretsConfigurator;
 use Dealroadshow\K8S\Framework\Core\ServiceAccount\Configurator\SecretsConfigurator;

--- a/src/Core/ServiceAccount/Configurator/ImagePullSecretsConfigurator.php
+++ b/src/Core/ServiceAccount/Configurator/ImagePullSecretsConfigurator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\ServiceAccount\Configurator;
 
-use Dealroadshow\K8S\Data\Collection\LocalObjectReferenceList;
+use Dealroadshow\K8S\Api\Core\V1\LocalObjectReferenceList;
 use Dealroadshow\K8S\Framework\Core\ManifestReference;
 use Dealroadshow\K8S\Framework\Core\Secret\SecretInterface;
 use Dealroadshow\K8S\Framework\Util\ManifestReferencesService;

--- a/src/Core/ServiceAccount/Configurator/SecretsConfigurator.php
+++ b/src/Core/ServiceAccount/Configurator/SecretsConfigurator.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\ServiceAccount\Configurator;
 
-use Dealroadshow\K8S\Data\Collection\ObjectReferenceList;
-use Dealroadshow\K8S\Data\ObjectReference;
+use Dealroadshow\K8S\Api\Core\V1\ObjectReference;
+use Dealroadshow\K8S\Api\Core\V1\ObjectReferenceList;
 use Dealroadshow\K8S\Framework\Core\ManifestReference;
 use Dealroadshow\K8S\Framework\Core\Secret\SecretInterface;
 use Dealroadshow\K8S\Framework\Util\ManifestReferencesService;

--- a/src/Core/ServiceAccount/ServiceAccountInterface.php
+++ b/src/Core/ServiceAccount/ServiceAccountInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\ServiceAccount;
 
-use Dealroadshow\K8S\API\ServiceAccount;
+use Dealroadshow\K8S\Api\Core\V1\ServiceAccount;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;
 use Dealroadshow\K8S\Framework\Core\ServiceAccount\Configurator\ImagePullSecretsConfigurator;
 use Dealroadshow\K8S\Framework\Core\ServiceAccount\Configurator\SecretsConfigurator;

--- a/src/Core/StatefulSet/AbstractStatefulSet.php
+++ b/src/Core/StatefulSet/AbstractStatefulSet.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\StatefulSet;
 
-use Dealroadshow\K8S\API\Apps\StatefulSet;
-use Dealroadshow\K8S\Data\Collection\StringMap;
-use Dealroadshow\K8S\Data\PodSpec;
+use Dealroadshow\K8S\Api\Apps\V1\StatefulSet;
+use Dealroadshow\K8S\Api\Core\V1\PodSpec;
+use Dealroadshow\K8S\Collection\StringMap;
 use Dealroadshow\K8S\Framework\Core\AbstractManifest;
 use Dealroadshow\K8S\Framework\Core\LabelSelector\SelectorConfigurator;
 use Dealroadshow\K8S\Framework\Core\ManifestReference;

--- a/src/Core/StatefulSet/StatefulSetInterface.php
+++ b/src/Core/StatefulSet/StatefulSetInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\StatefulSet;
 
-use Dealroadshow\K8S\API\Apps\StatefulSet;
+use Dealroadshow\K8S\Api\Apps\V1\StatefulSet;
 use Dealroadshow\K8S\Framework\Core\LabelSelector\SelectorConfigurator;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;
 use Dealroadshow\K8S\Framework\Core\ManifestReference;

--- a/src/Core/StatefulSet/UpdateStrategy/RollingUpdateStrategyConfigurator.php
+++ b/src/Core/StatefulSet/UpdateStrategy/RollingUpdateStrategyConfigurator.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\StatefulSet\UpdateStrategy;
 
-use Dealroadshow\K8S\Data\RollingUpdateStatefulSetStrategy;
+use Dealroadshow\K8S\Api\Apps\V1\RollingUpdateStatefulSetStrategy;
 
-class RollingUpdateStrategyConfigurator
+readonly class RollingUpdateStrategyConfigurator
 {
     public function __construct(private RollingUpdateStatefulSetStrategy $rollingUpdate)
     {

--- a/src/Core/StatefulSet/UpdateStrategy/UpdateStrategyConfigurator.php
+++ b/src/Core/StatefulSet/UpdateStrategy/UpdateStrategyConfigurator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core\StatefulSet\UpdateStrategy;
 
-use Dealroadshow\K8S\Data\StatefulSetUpdateStrategy;
+use Dealroadshow\K8S\Api\Apps\V1\StatefulSetUpdateStrategy;
 
 class UpdateStrategyConfigurator
 {

--- a/src/Core/VersionedManifestReference.php
+++ b/src/Core/VersionedManifestReference.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Core;
 
-use Dealroadshow\K8S\Data\CrossVersionObjectReference;
-
 final readonly class VersionedManifestReference
 {
     public function __construct(public string $appAlias, public string $className, public string|null $apiVersion = null)

--- a/src/Event/ConfigMapGeneratedEvent.php
+++ b/src/Event/ConfigMapGeneratedEvent.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Event;
 
-use Dealroadshow\K8S\API\ConfigMap;
+use Dealroadshow\K8S\Api\Core\V1\ConfigMap;
 use Dealroadshow\K8S\APIResourceInterface;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\ConfigMap\ConfigMapInterface;
 
-class ConfigMapGeneratedEvent implements ManifestGeneratedEventInterface
+readonly class ConfigMapGeneratedEvent implements ManifestGeneratedEventInterface
 {
     public const NAME = 'dealroadshow_k8s.manifest_generated.configMap';
 

--- a/src/Event/ContainerGeneratedEvent.php
+++ b/src/Event/ContainerGeneratedEvent.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Event;
 
-use Dealroadshow\K8S\Data\Container;
+use Dealroadshow\K8S\Api\Core\V1\Container;
 use Dealroadshow\K8S\Framework\Core\Container\ContainerInterface;
 
 class ContainerGeneratedEvent

--- a/src/Event/CronJobGeneratedEvent.php
+++ b/src/Event/CronJobGeneratedEvent.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Event;
 
-use Dealroadshow\K8S\API\Batch\CronJob;
+use Dealroadshow\K8S\Api\Batch\V1\CronJob;
 use Dealroadshow\K8S\APIResourceInterface;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\CronJob\CronJobInterface;
 
-class CronJobGeneratedEvent implements ManifestGeneratedEventInterface
+readonly class CronJobGeneratedEvent implements ManifestGeneratedEventInterface
 {
     public const NAME = 'dealroadshow_k8s.manifest_generated.cronJob';
 

--- a/src/Event/DeploymentGeneratedEvent.php
+++ b/src/Event/DeploymentGeneratedEvent.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Event;
 
-use Dealroadshow\K8S\API\Apps\Deployment;
+use Dealroadshow\K8S\Api\Apps\V1\Deployment;
 use Dealroadshow\K8S\APIResourceInterface;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\Deployment\DeploymentInterface;

--- a/src/Event/IngressGeneratedEvent.php
+++ b/src/Event/IngressGeneratedEvent.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Event;
 
-use Dealroadshow\K8S\API\Networking\Ingress;
+use Dealroadshow\K8S\Api\Networking\V1\Ingress;
 use Dealroadshow\K8S\APIResourceInterface;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\Ingress\IngressInterface;
 
-class IngressGeneratedEvent implements ManifestGeneratedEventInterface
+readonly class IngressGeneratedEvent implements ManifestGeneratedEventInterface
 {
     public const NAME = 'dealroadshow_k8s.manifest_generated.ingress';
 

--- a/src/Event/JobGeneratedEvent.php
+++ b/src/Event/JobGeneratedEvent.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Event;
 
-use Dealroadshow\K8S\API\Batch\Job;
+use Dealroadshow\K8S\Api\Batch\V1\Job;
 use Dealroadshow\K8S\APIResourceInterface;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\Job\JobInterface;
 
-class JobGeneratedEvent implements ManifestGeneratedEventInterface
+readonly class JobGeneratedEvent implements ManifestGeneratedEventInterface
 {
     public const NAME = 'dealroadshow_k8s.manifest_generated.job';
 

--- a/src/Event/PodSpecGeneratedEvent.php
+++ b/src/Event/PodSpecGeneratedEvent.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Event;
 
-use Dealroadshow\K8S\Data\PodSpec;
+use Dealroadshow\K8S\Api\Core\V1\PodSpec;
 use Dealroadshow\K8S\Framework\Core\Pod\PodSpecInterface;
 
 class PodSpecGeneratedEvent

--- a/src/Event/PodTemplateSpecGeneratedEvent.php
+++ b/src/Event/PodTemplateSpecGeneratedEvent.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Event;
 
-use Dealroadshow\K8S\Data\PodTemplateSpec;
+use Dealroadshow\K8S\Api\Core\V1\PodTemplateSpec;
 use Dealroadshow\K8S\Framework\Core\Pod\PodTemplateSpecInterface;
 
 class PodTemplateSpecGeneratedEvent

--- a/src/Event/SecretGeneratedEvent.php
+++ b/src/Event/SecretGeneratedEvent.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Event;
 
-use Dealroadshow\K8S\API\Secret;
+use Dealroadshow\K8S\Api\Core\V1\Secret;
 use Dealroadshow\K8S\APIResourceInterface;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\Secret\SecretInterface;
 
-class SecretGeneratedEvent implements ManifestGeneratedEventInterface
+readonly class SecretGeneratedEvent implements ManifestGeneratedEventInterface
 {
     public const NAME = 'dealroadshow_k8s.manifest_generated.secret';
 

--- a/src/Event/ServiceAccountGeneratedEvent.php
+++ b/src/Event/ServiceAccountGeneratedEvent.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Event;
 
-use Dealroadshow\K8S\API\ServiceAccount;
+use Dealroadshow\K8S\Api\Core\V1\ServiceAccount;
 use Dealroadshow\K8S\APIResourceInterface;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;

--- a/src/Event/ServiceGeneratedEvent.php
+++ b/src/Event/ServiceGeneratedEvent.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Event;
 
-use Dealroadshow\K8S\API\Service;
+use Dealroadshow\K8S\Api\Core\V1\Service;
 use Dealroadshow\K8S\APIResourceInterface;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\Service\ServiceInterface;

--- a/src/Event/StatefulSetGeneratedEvent.php
+++ b/src/Event/StatefulSetGeneratedEvent.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Event;
 
-use Dealroadshow\K8S\API\Apps\StatefulSet;
+use Dealroadshow\K8S\Api\Apps\V1\StatefulSet;
 use Dealroadshow\K8S\APIResourceInterface;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\StatefulSet\StatefulSetInterface;
 
-class StatefulSetGeneratedEvent implements ManifestGeneratedEventInterface
+readonly class StatefulSetGeneratedEvent implements ManifestGeneratedEventInterface
 {
     public const NAME = 'dealroadshow_k8s.manifest_generated.stateful_set';
 

--- a/src/Helper/Metadata/MetadataHelper.php
+++ b/src/Helper/Metadata/MetadataHelper.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Helper\Metadata;
 
+use Dealroadshow\K8S\Apimachinery\Pkg\Apis\Meta\V1\ObjectMeta;
 use Dealroadshow\K8S\APIResourceInterface;
-use Dealroadshow\K8S\Data\ObjectMeta;
 use Dealroadshow\K8S\Framework\Core\DynamicNameAwareInterface;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;
 use Dealroadshow\K8S\Framework\Core\MetadataAwareInterface;

--- a/src/Helper/Metadata/MetadataHelperInterface.php
+++ b/src/Helper/Metadata/MetadataHelperInterface.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Helper\Metadata;
 
+use Dealroadshow\K8S\Apimachinery\Pkg\Apis\Meta\V1\ObjectMeta;
 use Dealroadshow\K8S\APIResourceInterface;
-use Dealroadshow\K8S\Data\ObjectMeta;
 use Dealroadshow\K8S\Framework\Core\MetadataAwareInterface;
 use Dealroadshow\K8S\Framework\Helper\HelperInterface;
 

--- a/src/Monitoring/Prometheus/AbstractMonitor.php
+++ b/src/Monitoring/Prometheus/AbstractMonitor.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Monitoring\Prometheus;
 
-use Dealroadshow\K8S\Data\Collection\StringList;
+use Dealroadshow\K8S\Collection\StringList;
 use Dealroadshow\K8S\Framework\Core\AbstractManifest;
 use Dealroadshow\K8S\Framework\Monitoring\Prometheus\Configurator\NamespaceSelectorConfigurator;
 

--- a/src/Monitoring/Prometheus/AbstractPrometheusApiResource.php
+++ b/src/Monitoring/Prometheus/AbstractPrometheusApiResource.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Monitoring\Prometheus;
 
+use Dealroadshow\K8S\Apimachinery\Pkg\Apis\Meta\V1\ObjectMeta;
 use Dealroadshow\K8S\APIResourceInterface;
-use Dealroadshow\K8S\Data\ObjectMeta;
 
 abstract class AbstractPrometheusApiResource implements APIResourceInterface
 {

--- a/src/Monitoring/Prometheus/Configurator/GroupRuleConfigurator.php
+++ b/src/Monitoring/Prometheus/Configurator/GroupRuleConfigurator.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Monitoring\Prometheus\Configurator;
 
-use Dealroadshow\K8S\Data\Collection\StringMap;
+use Dealroadshow\K8S\Collection\StringMap;
 
 class GroupRuleConfigurator
 {

--- a/src/Monitoring/Prometheus/MonitorInterface.php
+++ b/src/Monitoring/Prometheus/MonitorInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Monitoring\Prometheus;
 
-use Dealroadshow\K8S\Data\Collection\StringList;
+use Dealroadshow\K8S\Collection\StringList;
 use Dealroadshow\K8S\Framework\Core\LabelSelector\SelectorConfigurator;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;
 use Dealroadshow\K8S\Framework\Monitoring\Prometheus\Configurator\NamespaceSelectorConfigurator;

--- a/src/Monitoring/Prometheus/ServiceMonitor/AbstractServiceMonitor.php
+++ b/src/Monitoring/Prometheus/ServiceMonitor/AbstractServiceMonitor.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Monitoring\Prometheus\ServiceMonitor;
 
-use Dealroadshow\K8S\Data\Collection\StringList;
+use Dealroadshow\K8S\Collection\StringList;
 use Dealroadshow\K8S\Framework\Monitoring\Prometheus\AbstractMonitor;
 
 abstract class AbstractServiceMonitor extends AbstractMonitor implements ServiceMonitorInterface

--- a/src/Monitoring/Prometheus/ServiceMonitor/ServiceMonitorInterface.php
+++ b/src/Monitoring/Prometheus/ServiceMonitor/ServiceMonitorInterface.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Monitoring\Prometheus\ServiceMonitor;
 
-use Dealroadshow\K8S\Data\Collection\StringList;
+use Dealroadshow\K8S\Collection\StringList;
 use Dealroadshow\K8S\Framework\Monitoring\Prometheus\Configurator\EndpointsConfigurator;
 use Dealroadshow\K8S\Framework\Monitoring\Prometheus\MonitorInterface;
 

--- a/src/ResourceMaker/AbstractRoleBindingMaker.php
+++ b/src/ResourceMaker/AbstractRoleBindingMaker.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\ResourceMaker;
 
-use Dealroadshow\K8S\API\Rbac\ClusterRoleBinding;
-use Dealroadshow\K8S\API\Rbac\RoleBinding;
-use Dealroadshow\K8S\Data\RoleRef;
+use Dealroadshow\K8S\Api\Rbac\V1\ClusterRoleBinding;
+use Dealroadshow\K8S\Api\Rbac\V1\RoleBinding;
+use Dealroadshow\K8S\Api\Rbac\V1\RoleRef;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;
 use Dealroadshow\K8S\Framework\Core\Rbac\ClusterRoleBindingInterface;

--- a/src/ResourceMaker/ClusterRoleBindingMaker.php
+++ b/src/ResourceMaker/ClusterRoleBindingMaker.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\ResourceMaker;
 
-use Dealroadshow\K8S\API\Rbac\ClusterRoleBinding;
-use Dealroadshow\K8S\Data\RoleRef;
+use Dealroadshow\K8S\Api\Rbac\V1\ClusterRoleBinding;
+use Dealroadshow\K8S\Api\Rbac\V1\RoleRef;
 use Dealroadshow\K8S\Framework\Core\Rbac\ClusterRoleBindingInterface;
 
 class ClusterRoleBindingMaker extends AbstractRoleBindingMaker

--- a/src/ResourceMaker/ClusterRoleMaker.php
+++ b/src/ResourceMaker/ClusterRoleMaker.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\ResourceMaker;
 
-use Dealroadshow\K8S\API\Rbac\ClusterRole;
+use Dealroadshow\K8S\Api\Rbac\V1\ClusterRole;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;
 use Dealroadshow\K8S\Framework\Core\Rbac\ClusterRoleInterface;

--- a/src/ResourceMaker/ConfigMapMaker.php
+++ b/src/ResourceMaker/ConfigMapMaker.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\ResourceMaker;
 
-use Dealroadshow\K8S\API\ConfigMap;
+use Dealroadshow\K8S\Api\Core\V1\ConfigMap;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\ConfigMap\ConfigMapInterface;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;
 use Dealroadshow\K8S\Framework\Event\ConfigMapGeneratedEvent;
 use Dealroadshow\K8S\Framework\ResourceMaker\Traits\PrefixMapKeysTrait;
-use Dealroadshow\K8S\Framework\Util\Str;
 use Dealroadshow\K8S\Framework\Util\StringMapProxy;
 
 class ConfigMapMaker extends AbstractResourceMaker

--- a/src/ResourceMaker/CronJobMaker.php
+++ b/src/ResourceMaker/CronJobMaker.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\ResourceMaker;
 
-use Dealroadshow\K8S\API\Batch\CronJob;
-use Dealroadshow\K8S\Data\CronJobSpec;
-use Dealroadshow\K8S\Data\JobTemplateSpec;
+use Dealroadshow\K8S\Api\Batch\V1\CronJob;
+use Dealroadshow\K8S\Api\Batch\V1\CronJobSpec;
+use Dealroadshow\K8S\Api\Batch\V1\JobTemplateSpec;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\CronJob\CronJobInterface;
 use Dealroadshow\K8S\Framework\Core\Job\JobInterface;
@@ -18,7 +18,7 @@ use Dealroadshow\K8S\Framework\Event\CronJobGeneratedEvent;
 
 class CronJobMaker extends AbstractResourceMaker
 {
-    private JobSpecProcessor $jobSpecProcessor;
+    private readonly JobSpecProcessor $jobSpecProcessor;
 
     public function __construct(JobSpecProcessor $jobSpecProcessor)
     {

--- a/src/ResourceMaker/DeploymentMaker.php
+++ b/src/ResourceMaker/DeploymentMaker.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\ResourceMaker;
 
-use Dealroadshow\K8S\API\Apps\Deployment;
-use Dealroadshow\K8S\Data\DeploymentStrategy;
+use Dealroadshow\K8S\Api\Apps\V1\Deployment;
+use Dealroadshow\K8S\Api\Apps\V1\DeploymentStrategy;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\Deployment\DeploymentInterface;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;
@@ -18,7 +18,7 @@ class DeploymentMaker extends AbstractResourceMaker
 {
     use ConfigureSelectorTrait;
 
-    public function __construct(private PodTemplateSpecProcessor $specProcessor)
+    public function __construct(private readonly PodTemplateSpecProcessor $specProcessor)
     {
     }
 

--- a/src/ResourceMaker/HorizontalPodAutoscalerMaker.php
+++ b/src/ResourceMaker/HorizontalPodAutoscalerMaker.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\ResourceMaker;
 
-use Dealroadshow\K8S\API\Autoscaling\HorizontalPodAutoscaler;
+use Dealroadshow\K8S\Api\Autoscaling\V2\CrossVersionObjectReference;
+use Dealroadshow\K8S\Api\Autoscaling\V2\HorizontalPodAutoscaler;
+use Dealroadshow\K8S\Api\Autoscaling\V2\HorizontalPodAutoscalerSpec;
 use Dealroadshow\K8S\APIResourceInterface;
-use Dealroadshow\K8S\Data\CrossVersionObjectReference;
-use Dealroadshow\K8S\Data\HorizontalPodAutoscalerSpec;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\Autoscaling\Configurator\BehaviorConfigurator;
 use Dealroadshow\K8S\Framework\Core\Autoscaling\Configurator\MetricsConfigurator;
@@ -18,7 +18,7 @@ use Dealroadshow\K8S\Framework\Util\VersionedManifestReferencesService;
 
 class HorizontalPodAutoscalerMaker extends AbstractResourceMaker
 {
-    public function __construct(private VersionedManifestReferencesService $referencesService)
+    public function __construct(private readonly VersionedManifestReferencesService $referencesService)
     {
     }
 

--- a/src/ResourceMaker/IngressMaker.php
+++ b/src/ResourceMaker/IngressMaker.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\ResourceMaker;
 
-use Dealroadshow\K8S\API\Networking\Ingress;
+use Dealroadshow\K8S\Api\Networking\V1\Ingress;
 use Dealroadshow\K8S\APIResourceInterface;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\Ingress\Configurator\IngressBackendConfigurator;

--- a/src/ResourceMaker/JobMaker.php
+++ b/src/ResourceMaker/JobMaker.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\ResourceMaker;
 
-use Dealroadshow\K8S\API\Batch\Job;
+use Dealroadshow\K8S\Api\Batch\V1\Job;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\CronJob\CronJobInterface;
 use Dealroadshow\K8S\Framework\Core\Job\JobInterface;

--- a/src/ResourceMaker/PersistentVolumeClaimMaker.php
+++ b/src/ResourceMaker/PersistentVolumeClaimMaker.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\ResourceMaker;
 
-use Dealroadshow\K8S\API\PersistentVolumeClaim;
+use Dealroadshow\K8S\Api\Core\V1\PersistentVolumeClaim;
 use Dealroadshow\K8S\APIResourceInterface;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\LabelSelector\SelectorConfigurator;

--- a/src/ResourceMaker/PriorityClassMaker.php
+++ b/src/ResourceMaker/PriorityClassMaker.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\ResourceMaker;
 
-use Dealroadshow\K8S\API\Scheduling\PriorityClass;
+use Dealroadshow\K8S\Api\Scheduling\V1\PriorityClass;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;
 use Dealroadshow\K8S\Framework\Core\PriorityClass\PriorityClassInterface;

--- a/src/ResourceMaker/Prometheus/AbstractMonitorMaker.php
+++ b/src/ResourceMaker/Prometheus/AbstractMonitorMaker.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\ResourceMaker\Prometheus;
 
+use Dealroadshow\K8S\Apimachinery\Pkg\Apis\Meta\V1\LabelSelector;
+use Dealroadshow\K8S\Apimachinery\Pkg\Apis\Meta\V1\ObjectMeta;
 use Dealroadshow\K8S\APIResourceInterface;
-use Dealroadshow\K8S\Data\Collection\StringList;
-use Dealroadshow\K8S\Data\LabelSelector;
-use Dealroadshow\K8S\Data\ObjectMeta;
+use Dealroadshow\K8S\Collection\StringList;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;
 use Dealroadshow\K8S\Framework\Monitoring\Prometheus\Configurator\NamespaceSelectorConfigurator;

--- a/src/ResourceMaker/Prometheus/PrometheusRuleMaker.php
+++ b/src/ResourceMaker/Prometheus/PrometheusRuleMaker.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\ResourceMaker\Prometheus;
 
+use Dealroadshow\K8S\Apimachinery\Pkg\Apis\Meta\V1\ObjectMeta;
 use Dealroadshow\K8S\APIResourceInterface;
-use Dealroadshow\K8S\Data\ObjectMeta;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;
 use Dealroadshow\K8S\Framework\Monitoring\Prometheus\Configurator\RuleGroupsConfigurator;

--- a/src/ResourceMaker/Prometheus/ServiceMonitorMaker.php
+++ b/src/ResourceMaker/Prometheus/ServiceMonitorMaker.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\ResourceMaker\Prometheus;
 
-use Dealroadshow\K8S\Data\Collection\StringList;
+use Dealroadshow\K8S\Collection\StringList;
 use Dealroadshow\K8S\Framework\Monitoring\Prometheus\Configurator\EndpointsConfigurator;
 use Dealroadshow\K8S\Framework\Monitoring\Prometheus\MonitorInterface;
 use Dealroadshow\K8S\Framework\Monitoring\Prometheus\ServiceMonitor\ServiceMonitorInterface;

--- a/src/ResourceMaker/RoleBindingMaker.php
+++ b/src/ResourceMaker/RoleBindingMaker.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\ResourceMaker;
 
-use Dealroadshow\K8S\API\Rbac\RoleBinding;
-use Dealroadshow\K8S\Data\RoleRef;
+use Dealroadshow\K8S\Api\Rbac\V1\RoleBinding;
+use Dealroadshow\K8S\Api\Rbac\V1\RoleRef;
 use Dealroadshow\K8S\Framework\Core\Rbac\RoleBindingInterface;
 
 class RoleBindingMaker extends AbstractRoleBindingMaker

--- a/src/ResourceMaker/RoleMaker.php
+++ b/src/ResourceMaker/RoleMaker.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\ResourceMaker;
 
-use Dealroadshow\K8S\API\Rbac\Role;
+use Dealroadshow\K8S\Api\Rbac\V1\Role;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;
 use Dealroadshow\K8S\Framework\Core\Rbac\Configurator\PolicyRulesConfigurator;

--- a/src/ResourceMaker/SecretMaker.php
+++ b/src/ResourceMaker/SecretMaker.php
@@ -4,13 +4,12 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\ResourceMaker;
 
-use Dealroadshow\K8S\API\Secret;
+use Dealroadshow\K8S\Api\Core\V1\Secret;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;
 use Dealroadshow\K8S\Framework\Core\Secret\SecretInterface;
 use Dealroadshow\K8S\Framework\Event\SecretGeneratedEvent;
 use Dealroadshow\K8S\Framework\ResourceMaker\Traits\PrefixMapKeysTrait;
-use Dealroadshow\K8S\Framework\Util\Str;
 use Dealroadshow\K8S\Framework\Util\StringMapProxy;
 
 class SecretMaker extends AbstractResourceMaker

--- a/src/ResourceMaker/ServiceAccountMaker.php
+++ b/src/ResourceMaker/ServiceAccountMaker.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\ResourceMaker;
 
-use Dealroadshow\K8S\API\ServiceAccount;
+use Dealroadshow\K8S\Api\Core\V1\ServiceAccount;
 use Dealroadshow\K8S\APIResourceInterface;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;

--- a/src/ResourceMaker/ServiceMaker.php
+++ b/src/ResourceMaker/ServiceMaker.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\ResourceMaker;
 
-use Dealroadshow\K8S\API\Service;
+use Dealroadshow\K8S\Api\Core\V1\Service;
+use Dealroadshow\K8S\Api\Core\V1\ServicePortList;
 use Dealroadshow\K8S\APIResourceInterface;
-use Dealroadshow\K8S\Data\Collection\ServicePortList;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;
 use Dealroadshow\K8S\Framework\Core\Service\Configurator\ServicePortsConfigurator;

--- a/src/ResourceMaker/StatefulSetMaker.php
+++ b/src/ResourceMaker/StatefulSetMaker.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\ResourceMaker;
 
-use Dealroadshow\K8S\API\Apps\StatefulSet;
+use Dealroadshow\K8S\Api\Apps\V1\StatefulSet;
+use Dealroadshow\K8S\Api\Apps\V1\StatefulSetSpec;
 use Dealroadshow\K8S\APIResourceInterface;
-use Dealroadshow\K8S\Data\StatefulSetSpec;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;
 use Dealroadshow\K8S\Framework\Core\Pod\PodTemplateSpecProcessor;
@@ -22,10 +22,10 @@ class StatefulSetMaker extends AbstractResourceMaker
     use ConfigureSelectorTrait;
 
     public function __construct(
-        private AppRegistry $appRegistry,
-        private PersistentVolumeClaimMaker $pvcMaker,
-        private PodTemplateSpecProcessor $podSpecProcessor,
-        private ProxyFactory $proxyFactory
+        private readonly AppRegistry $appRegistry,
+        private readonly PersistentVolumeClaimMaker $pvcMaker,
+        private readonly PodTemplateSpecProcessor $podSpecProcessor,
+        private readonly ProxyFactory $proxyFactory
     ) {
     }
 

--- a/src/ResourceMaker/Traits/ConfigureSelectorTrait.php
+++ b/src/ResourceMaker/Traits/ConfigureSelectorTrait.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\ResourceMaker\Traits;
 
-use Dealroadshow\K8S\Data\LabelSelector;
+use Dealroadshow\K8S\Apimachinery\Pkg\Apis\Meta\V1\LabelSelector;
 use Dealroadshow\K8S\Framework\Core\LabelSelector\SelectorConfigurator;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;
 use Dealroadshow\K8S\Framework\Util\ClassName;

--- a/src/ResourceMaker/Traits/PrefixMapKeysTrait.php
+++ b/src/ResourceMaker/Traits/PrefixMapKeysTrait.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\ResourceMaker\Traits;
 
-use Dealroadshow\K8S\Data\Collection\StringMap;
+use Dealroadshow\K8S\Collection\StringMap;
 
 trait PrefixMapKeysTrait
 {

--- a/src/Util/ManifestReferencesService.php
+++ b/src/Util/ManifestReferencesService.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Util;
 
-use Dealroadshow\K8S\Data\LocalObjectReference;
-use Dealroadshow\K8S\Data\ObjectReference;
-use Dealroadshow\K8S\Data\TypedLocalObjectReference;
+use Dealroadshow\K8S\Api\Core\V1\LocalObjectReference;
+use Dealroadshow\K8S\Api\Core\V1\ObjectReference;
+use Dealroadshow\K8S\Api\Core\V1\TypedLocalObjectReference;
 use Dealroadshow\K8S\Framework\Core\ManifestReference;
 use Dealroadshow\K8S\Framework\Registry\AppRegistry;
 

--- a/src/Util/StringMapProxy.php
+++ b/src/Util/StringMapProxy.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Util;
 
-use Dealroadshow\K8S\Data\Collection\StringMap;
+use Dealroadshow\K8S\Collection\StringMap;
 
 class StringMapProxy extends StringMap
 {

--- a/src/Util/VersionedManifestReferencesService.php
+++ b/src/Util/VersionedManifestReferencesService.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\Util;
 
-use Dealroadshow\K8S\Data\CrossVersionObjectReference;
+use Dealroadshow\K8S\Api\Autoscaling\V2\CrossVersionObjectReference;
 use Dealroadshow\K8S\Framework\Core\VersionedManifestReference;
 use Dealroadshow\K8S\Framework\Registry\AppRegistry;
 


### PR DESCRIPTION
There was a critical bug in previous version of `k8s-resources`. It was fixed by remaking entire namespaces structure for `k8s-resources`. This PR adapts these changes in `k8s-resources` to K8S framework