### PR TITLE
fix: remove return type from `LocalizationStrategyInterface::localize()`

### DIFF
--- a/src/App/Integration/Localization/LocalizationStrategyInterface.php
+++ b/src/App/Integration/Localization/LocalizationStrategyInterface.php
@@ -31,5 +31,5 @@ interface LocalizationStrategyInterface
      *     'app3' => [App3ManifestOne::class],
      * ]
      */
-    public function localize(string $dependentAppAlias, array $dependencies): mixed;
+    public function localize(string $dependentAppAlias, array $dependencies);
 }


### PR DESCRIPTION
Removes return type from `LocalizationStrategyInterface::localize()` method in order to give more flexibility to implementation classes