### PR TITLE
Fix external env sources tracking logic

### DIFF
--- a/src/App/Integration/EnvSourcesRegistry.php
+++ b/src/App/Integration/EnvSourcesRegistry.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\App\Integration;
 
-class ExternalEnvSourcesRegistry
+class EnvSourcesRegistry
 {
     private array $sources = [];
 

--- a/src/App/Integration/EnvSourcesTrackingContext.php
+++ b/src/App/Integration/EnvSourcesTrackingContext.php
@@ -4,21 +4,17 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\App\Integration;
 
-final readonly class ExternalEnvSourcesTrackingContext
+final readonly class EnvSourcesTrackingContext
 {
     public function __construct(
         public string $dependentAppAlias,
         public string $dependencyAppAlias,
-        private ExternalEnvSourcesRegistry $registry
+        private EnvSourcesRegistry $registry
     ) {
     }
 
     public function trackDependency(string $manifestClass): void
     {
-        if ($this->dependentAppAlias === $this->dependencyAppAlias) {
-            return;
-        }
-
         $this->registry->trackDependency($this->dependentAppAlias, $this->dependencyAppAlias, $manifestClass);
     }
 }

--- a/src/App/Integration/ExternalEnvSourcesTrackingContext.php
+++ b/src/App/Integration/ExternalEnvSourcesTrackingContext.php
@@ -15,6 +15,10 @@ final readonly class ExternalEnvSourcesTrackingContext
 
     public function trackDependency(string $manifestClass): void
     {
+        if ($this->dependentAppAlias === $this->dependencyAppAlias) {
+            return;
+        }
+
         $this->registry->trackDependency($this->dependentAppAlias, $this->dependencyAppAlias, $manifestClass);
     }
 }

--- a/src/App/Integration/Localization/AbstractLocalizationStrategy.php
+++ b/src/App/Integration/Localization/AbstractLocalizationStrategy.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace Dealroadshow\K8S\Framework\App\Integration\Localization;
 
-use Dealroadshow\K8S\Framework\App\Integration\ExternalEnvSourcesRegistry;
+use Dealroadshow\K8S\Framework\App\Integration\EnvSourcesRegistry;
 
 abstract class AbstractLocalizationStrategy implements LocalizationStrategyInterface
 {
-    protected readonly ExternalEnvSourcesRegistry $envSourcesRegistry;
+    protected readonly EnvSourcesRegistry $envSourcesRegistry;
 
-    public function setEnvSourcesRegistry(ExternalEnvSourcesRegistry $envSourcesRegistry): void
+    public function setEnvSourcesRegistry(EnvSourcesRegistry $envSourcesRegistry): void
     {
         $this->envSourcesRegistry = $envSourcesRegistry;
     }

--- a/src/App/Integration/Localization/LocalizationStrategyInterface.php
+++ b/src/App/Integration/Localization/LocalizationStrategyInterface.php
@@ -17,7 +17,7 @@ namespace Dealroadshow\K8S\Framework\App\Integration\Localization;
  * dependent app needs from external ConfigMaps and Secrets. So every strategy defines its own means
  * of localization.
  *
- * Strategies will probably use @see \Dealroadshow\K8S\Framework\App\Integration\ExternalEnvSourcesRegistry
+ * Strategies will probably use @see \Dealroadshow\K8S\Framework\App\Integration\EnvSourcesRegistry
  * in order to get information about dependencies of the dependent apps.
  */
 interface LocalizationStrategyInterface

--- a/src/Core/Container/ContainerMaker.php
+++ b/src/Core/Container/ContainerMaker.php
@@ -32,7 +32,7 @@ readonly class ContainerMaker implements ContainerMakerInterface
         private AppRegistry $appRegistry,
         private EventDispatcherInterface $dispatcher,
         private ProxyFactory $proxyFactory,
-        private EnvSourcesRegistry $externalEnvSourcesRegistry,
+        private EnvSourcesRegistry $envSourcesRegistry,
         private iterable $middlewares
     ) {
     }
@@ -53,7 +53,7 @@ readonly class ContainerMaker implements ContainerMakerInterface
             $container->envFrom(),
             $app,
             $this->appRegistry,
-            $this->externalEnvSourcesRegistry
+            $this->envSourcesRegistry
         );
         $builder->env($env);
 

--- a/src/Core/Container/ContainerMaker.php
+++ b/src/Core/Container/ContainerMaker.php
@@ -7,7 +7,7 @@ namespace Dealroadshow\K8S\Framework\Core\Container;
 use Dealroadshow\K8S\Api\Core\V1\Container;
 use Dealroadshow\K8S\Api\Core\V1\VolumeList;
 use Dealroadshow\K8S\Framework\App\AppInterface;
-use Dealroadshow\K8S\Framework\App\Integration\ExternalEnvSourcesRegistry;
+use Dealroadshow\K8S\Framework\App\Integration\EnvSourcesRegistry;
 use Dealroadshow\K8S\Framework\Core\Container\Env\EnvConfigurator;
 use Dealroadshow\K8S\Framework\Core\Container\Image\Image;
 use Dealroadshow\K8S\Framework\Core\Container\Lifecycle\LifecycleConfigurator;
@@ -32,7 +32,7 @@ readonly class ContainerMaker implements ContainerMakerInterface
         private AppRegistry $appRegistry,
         private EventDispatcherInterface $dispatcher,
         private ProxyFactory $proxyFactory,
-        private ExternalEnvSourcesRegistry $externalEnvSourcesRegistry,
+        private EnvSourcesRegistry $externalEnvSourcesRegistry,
         private iterable $middlewares
     ) {
     }

--- a/src/Core/Container/Env/EnvConfigurator.php
+++ b/src/Core/Container/Env/EnvConfigurator.php
@@ -12,8 +12,8 @@ use Dealroadshow\K8S\Api\Core\V1\EnvVar;
 use Dealroadshow\K8S\Api\Core\V1\EnvVarList;
 use Dealroadshow\K8S\Api\Core\V1\SecretKeySelector;
 use Dealroadshow\K8S\Framework\App\AppInterface;
-use Dealroadshow\K8S\Framework\App\Integration\ExternalEnvSourcesRegistry;
-use Dealroadshow\K8S\Framework\App\Integration\ExternalEnvSourcesTrackingContext;
+use Dealroadshow\K8S\Framework\App\Integration\EnvSourcesRegistry;
+use Dealroadshow\K8S\Framework\App\Integration\EnvSourcesTrackingContext;
 use Dealroadshow\K8S\Framework\Core\ConfigMap\ConfigMapInterface;
 use Dealroadshow\K8S\Framework\Core\Container\Resources\ContainerResourcesField;
 use Dealroadshow\K8S\Framework\Core\Pod\PodField;
@@ -27,8 +27,8 @@ readonly class EnvConfigurator
         private EnvFromSourceList $sources,
         private AppInterface $app,
         private AppRegistry $appRegistry,
-        private ExternalEnvSourcesRegistry $externalEnvSourcesRegistry,
-        private ExternalEnvSourcesTrackingContext|null $externalEnvSourcesTrackingContext = null
+        private EnvSourcesRegistry $externalEnvSourcesRegistry,
+        private EnvSourcesTrackingContext|null $externalEnvSourcesTrackingContext = null
     ) {
     }
 
@@ -205,7 +205,7 @@ readonly class EnvConfigurator
         // In such case the true dependent app is the first one, not intermediate ones used in consecutive calls.
         $dependentAppAlias = $this->externalEnvSourcesTrackingContext?->dependentAppAlias ?? $this->app->alias();
 
-        $externalSourcesTrackingContext = new ExternalEnvSourcesTrackingContext(
+        $externalSourcesTrackingContext = new EnvSourcesTrackingContext(
             $dependentAppAlias,
             $appAlias,
             $this->externalEnvSourcesRegistry

--- a/src/Core/Container/Env/EnvConfigurator.php
+++ b/src/Core/Container/Env/EnvConfigurator.php
@@ -27,8 +27,8 @@ readonly class EnvConfigurator
         private EnvFromSourceList $sources,
         private AppInterface $app,
         private AppRegistry $appRegistry,
-        private EnvSourcesRegistry $externalEnvSourcesRegistry,
-        private EnvSourcesTrackingContext|null $externalEnvSourcesTrackingContext = null
+        private EnvSourcesRegistry $envSourcesRegistry,
+        private EnvSourcesTrackingContext|null $envSourcesTrackingContext = null
     ) {
     }
 
@@ -80,7 +80,7 @@ readonly class EnvConfigurator
     {
         $this->ensureAppOwnsManifestClass($configMapClass);
         $cmName = $this->app->namesHelper()->byConfigMapClass($configMapClass);
-        $this->externalEnvSourcesTrackingContext?->trackDependency($configMapClass);
+        $this->envSourcesTrackingContext?->trackDependency($configMapClass);
 
         return $this->addConfigMapByName($cmName, $mustExist, $varNamesPrefix);
     }
@@ -108,7 +108,7 @@ readonly class EnvConfigurator
     {
         $this->ensureAppOwnsManifestClass($secretClass);
         $secretName = $this->app->namesHelper()->bySecretClass($secretClass);
-        $this->externalEnvSourcesTrackingContext?->trackDependency($secretClass);
+        $this->envSourcesTrackingContext?->trackDependency($secretClass);
 
         return $this->addSecretByName($secretName, $mustExist);
     }
@@ -140,7 +140,7 @@ readonly class EnvConfigurator
         $this->ensureAppOwnsManifestClass($configMapClass);
         $cmName = $this->app->namesHelper()->byConfigMapClass($configMapClass);
 
-        $this->externalEnvSourcesTrackingContext?->trackDependency($configMapClass);
+        $this->envSourcesTrackingContext?->trackDependency($configMapClass);
 
         $keySelector = new ConfigMapKeySelector($configMapKey);
         $keySelector
@@ -159,7 +159,7 @@ readonly class EnvConfigurator
         $this->ensureAppOwnsManifestClass($secretClass);
         $secretName = $this->app->namesHelper()->bySecretClass($secretClass);
 
-        $this->externalEnvSourcesTrackingContext?->trackDependency($secretClass);
+        $this->envSourcesTrackingContext?->trackDependency($secretClass);
 
         $keySelector = new SecretKeySelector($secretKey);
         $keySelector
@@ -203,12 +203,12 @@ readonly class EnvConfigurator
         //     ->withExternalApp('anotherAppAlias')->addConfigMap(MyOtherConfigMap::class);
         // e.g. withExternalApp() is called multiple times in a row.
         // In such case the true dependent app is the first one, not intermediate ones used in consecutive calls.
-        $dependentAppAlias = $this->externalEnvSourcesTrackingContext?->dependentAppAlias ?? $this->app->alias();
+        $dependentAppAlias = $this->envSourcesTrackingContext?->dependentAppAlias ?? $this->app->alias();
 
         $externalSourcesTrackingContext = new EnvSourcesTrackingContext(
             $dependentAppAlias,
             $appAlias,
-            $this->externalEnvSourcesRegistry
+            $this->envSourcesRegistry
         );
 
         return new EnvConfigurator(
@@ -216,7 +216,7 @@ readonly class EnvConfigurator
             $this->sources,
             $this->appRegistry->get($appAlias),
             $this->appRegistry,
-            $this->externalEnvSourcesRegistry,
+            $this->envSourcesRegistry,
             $externalSourcesTrackingContext
         );
     }


### PR DESCRIPTION
Since tracking env sources is generic logic and can track all env sources (not only external), the word `External` removed from related class names
