### PR TITLE
feat: runtime resolver for manifests / app status

### DIFF
--- a/src/Registry/AppRegistry.php
+++ b/src/Registry/AppRegistry.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Dealroadshow\K8S\Framework\Registry;
 
 use Dealroadshow\K8S\Framework\App\AppInterface;
+use Dealroadshow\K8S\Framework\Runtime\ManifestRuntimeStatusResolverInterface;
 
 class AppRegistry
 {
@@ -13,12 +14,20 @@ class AppRegistry
      */
     private array $apps = [];
 
+    public function __construct(private readonly ManifestRuntimeStatusResolverInterface $statusResolver)
+    {
+    }
+
     public function add(string $alias, AppInterface $app): void
     {
         if ($this->has($alias)) {
             throw new \InvalidArgumentException(
                 sprintf('App with alias "%s" already exists', $alias)
             );
+        }
+
+        if (!$this->statusResolver->isClassEnabled(new \ReflectionClass($app))) {
+            return;
         }
 
         $this->apps[$alias] = $app;

--- a/src/Registry/ManifestRegistry.php
+++ b/src/Registry/ManifestRegistry.php
@@ -7,6 +7,7 @@ namespace Dealroadshow\K8S\Framework\Registry;
 use Dealroadshow\K8S\Framework\Core\ManifestInterface;
 use Dealroadshow\K8S\Framework\Proxy\ProxyFactory;
 use Dealroadshow\K8S\Framework\Registry\Query\ManifestsQuery;
+use Dealroadshow\K8S\Framework\Runtime\ManifestRuntimeStatusResolverInterface;
 use Dealroadshow\K8S\Framework\Util\ManifestShortName;
 use Dealroadshow\Proximity\ProxyInterface;
 
@@ -17,8 +18,10 @@ class ManifestRegistry
      */
     private array $manifests = [];
 
-    public function __construct(private ProxyFactory $proxyFactory)
-    {
+    public function __construct(
+        private readonly ProxyFactory $proxyFactory,
+        private readonly ManifestRuntimeStatusResolverInterface $statusResolver
+    ) {
     }
 
     /**
@@ -45,6 +48,10 @@ class ManifestRegistry
                     $manifest::class
                 )
             );
+        }
+
+        if (!$this->statusResolver->isClassEnabled(new \ReflectionClass($manifest))) {
+            return;
         }
 
         $this->manifests[$appAlias][] = $this->proxyFactory->makeProxy($manifest);

--- a/src/Runtime/DelegatingRuntimeStatusResolver.php
+++ b/src/Runtime/DelegatingRuntimeStatusResolver.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dealroadshow\K8S\Framework\Runtime;
+
+final readonly class DelegatingRuntimeStatusResolver implements ManifestRuntimeStatusResolverInterface
+{
+    /**
+     * @param ManifestStatusResolverStrategyInterface[] $strategies
+     */
+    public function __construct(private iterable $strategies)
+    {
+    }
+
+    public function isClassEnabled(\ReflectionClass $class): bool
+    {
+        foreach ($this->strategies as $strategy) {
+            if (!$strategy->isClassEnabled($class)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/Runtime/ManifestRuntimeStatusResolverInterface.php
+++ b/src/Runtime/ManifestRuntimeStatusResolverInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dealroadshow\K8S\Framework\Runtime;
+
+interface ManifestRuntimeStatusResolverInterface
+{
+    public function isClassEnabled(\ReflectionClass $class): bool;
+}

--- a/src/Runtime/ManifestStatusResolverStrategyInterface.php
+++ b/src/Runtime/ManifestStatusResolverStrategyInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dealroadshow\K8S\Framework\Runtime;
+
+interface ManifestStatusResolverStrategyInterface
+{
+    public function isClassEnabled(\ReflectionClass $class): bool;
+}


### PR DESCRIPTION
Adds a logic to resolve manifest / app status at runtime in order to replace this logic in K8S bundle, that for now uses DI container compilation stage (which is bad, because requires env vars resolution at compilation stage instead of runtime)