### PR TITLE
Self rendering manifests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.3",
         "ext-json": "*",
         "symfony/yaml": ">=6.0",
         "dealroadshow/k8s-resources": ">=1.30",
@@ -29,5 +29,8 @@
         "psr-4": {
             "Dealroadshow\\K8S\\Framework\\": "src/"
         }
+    },
+    "scripts": {
+        "cs": "PHP_CS_FIXER_IGNORE_ENV=true ./tools/php-cs-fixer/vendor/bin/php-cs-fixer fix"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": ">=8.3",
+        "php": ">=8.2",
         "ext-json": "*",
         "symfony/yaml": ">=6.0",
         "dealroadshow/k8s-resources": ">=1.30",

--- a/src/Core/AbstractSelfRenderingManifest.php
+++ b/src/Core/AbstractSelfRenderingManifest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dealroadshow\K8S\Framework\Core;
+
+use Dealroadshow\K8S\APIResourceInterface;
+
+abstract class AbstractSelfRenderingManifest extends AbstractManifest implements SelfRenderingManifestInterface
+{
+    abstract public function data(): array|\JsonSerializable;
+    abstract public static function apiVersion(): string;
+    abstract public static function kind(): string;
+
+    public function render(): ApiResourceInterface
+    {
+        $data = $this->data();
+        if ($data instanceof \JsonSerializable) {
+            $encoded = json_encode($data);
+            if (false === $encoded) {
+                throw new \RuntimeException(sprintf('Failed to encode data to JSON: %s. Data: "%s"', json_last_error_msg(), var_export($data, true)));
+            }
+            $data = json_decode($encoded, true);
+        }
+
+        return new GenericApiResource(static::apiVersion(), static::kind(), $this->data());
+    }
+}

--- a/src/Core/GenericApiResource.php
+++ b/src/Core/GenericApiResource.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dealroadshow\K8S\Framework\Core;
+
+use Dealroadshow\K8S\Apimachinery\Pkg\Apis\Meta\V1\ObjectMeta;
+use Dealroadshow\K8S\APIResourceInterface;
+
+class GenericApiResource implements APIResourceInterface
+{
+    private ObjectMeta $metadata;
+
+    public function __construct(
+        private readonly string $apiVersion,
+        private readonly string $kind,
+        private readonly array $data = []
+    ) {
+        $this->metadata = new ObjectMeta();
+    }
+
+    public function metadata(): ObjectMeta
+    {
+        return $this->metadata;
+    }
+
+    public function jsonSerialize(): array|\JsonSerializable
+    {
+        $commonData = [
+            'apiVersion' => $this->apiVersion,
+            'kind' => $this->kind,
+            'metadata' => $this->metadata,
+        ];
+
+        return array_merge($commonData, $this->data);
+    }
+}

--- a/src/Core/SelfRenderingManifestInterface.php
+++ b/src/Core/SelfRenderingManifestInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dealroadshow\K8S\Framework\Core;
+
+use Dealroadshow\K8S\APIResourceInterface;
+
+interface SelfRenderingManifestInterface extends ManifestInterface
+{
+    public function render(): ApiResourceInterface;
+}

--- a/src/ResourceMaker/SelfRenderingManifestResourceMaker.php
+++ b/src/ResourceMaker/SelfRenderingManifestResourceMaker.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Dealroadshow\K8S\Framework\ResourceMaker;
+
+use Dealroadshow\K8S\APIResourceInterface;
+use Dealroadshow\K8S\Framework\App\AppInterface;
+use Dealroadshow\K8S\Framework\Core\ManifestInterface;
+use Dealroadshow\K8S\Framework\Core\SelfRenderingManifestInterface;
+
+class SelfRenderingManifestResourceMaker extends AbstractResourceMaker
+{
+    protected function supportsClass(): string
+    {
+        return SelfRenderingManifestInterface::class;
+    }
+
+    protected function makeResource(ManifestInterface|SelfRenderingManifestInterface $manifest, AppInterface $app): APIResourceInterface
+    {
+        return $manifest->render();
+    }
+}


### PR DESCRIPTION
Adds new feature: self-rendering manifests, e.g. manifests that render themselves into `ApiResourceInterface` using `render()` method. This comes in hand when K8S framework ecosystem does not have a definition for a desired CRD
