### PR TITLE
feat: external configurations registry in EnvConfigurator

### DIFF
--- a/src/Core/Container/ContainerMaker.php
+++ b/src/Core/Container/ContainerMaker.php
@@ -9,6 +9,7 @@ use Dealroadshow\K8S\Api\Core\V1\VolumeList;
 use Dealroadshow\K8S\Framework\App\AppInterface;
 use Dealroadshow\K8S\Framework\App\Integration\EnvSourcesRegistry;
 use Dealroadshow\K8S\Framework\Core\Container\Env\EnvConfigurator;
+use Dealroadshow\K8S\Framework\Core\Container\Env\ExternalConfigurationRegistry;
 use Dealroadshow\K8S\Framework\Core\Container\Image\Image;
 use Dealroadshow\K8S\Framework\Core\Container\Lifecycle\LifecycleConfigurator;
 use Dealroadshow\K8S\Framework\Core\Container\Lifecycle\Probes\ProbesConfigurator;
@@ -33,6 +34,7 @@ readonly class ContainerMaker implements ContainerMakerInterface
         private EventDispatcherInterface $dispatcher,
         private ProxyFactory $proxyFactory,
         private EnvSourcesRegistry $envSourcesRegistry,
+        private ExternalConfigurationRegistry $externalConfigurations,
         private iterable $middlewares
     ) {
     }
@@ -55,6 +57,7 @@ readonly class ContainerMaker implements ContainerMakerInterface
             $this->appRegistry,
             $this->envSourcesRegistry,
             $this->dispatcher,
+            $this->externalConfigurations,
         );
         $builder->env($env);
 

--- a/src/Core/Container/Env/EnvConfigurator.php
+++ b/src/Core/Container/Env/EnvConfigurator.php
@@ -35,6 +35,7 @@ readonly class EnvConfigurator
         private AppRegistry $appRegistry,
         private EnvSourcesRegistry $envSourcesRegistry,
         private EventDispatcherInterface $dispatcher,
+        private ExternalConfigurationRegistry $externalConfigurations,
         private EnvSourcesTrackingContext|null $envSourcesTrackingContext = null
     ) {
     }
@@ -103,12 +104,8 @@ readonly class EnvConfigurator
         return $this;
     }
 
-    public function addConfigMapByName(string $configMapName, bool $mustExist = true, string|null $varNamesPrefix = null): static
+    public function addConfigMapByName(string $configMapName, bool $mustExist = true, string|null $varNamesPrefix = null, bool $external = false): static
     {
-        $source = new ConfigMapEnvSource();
-        $source
-            ->setName($configMapName)
-            ->setOptional(!$mustExist);
         $envFromSource = new EnvFromSource();
         if (null !== $varNamesPrefix) {
             $envFromSource->setPrefix($varNamesPrefix);
@@ -118,6 +115,10 @@ readonly class EnvConfigurator
             ->setOptional(!$mustExist);
 
         $this->sources->add($envFromSource);
+
+        if ($external) {
+            $this->externalConfigurations->addConfigMap($configMapName);
+        }
 
         return $this;
     }
@@ -142,7 +143,7 @@ readonly class EnvConfigurator
         return $this;
     }
 
-    public function addSecretByName(string $secretName, bool $mustExist = true): static
+    public function addSecretByName(string $secretName, bool $mustExist = true, bool $external = false): static
     {
         $envFromSource = new EnvFromSource();
         $envFromSource->secretRef()
@@ -150,6 +151,10 @@ readonly class EnvConfigurator
             ->setOptional(!$mustExist);
 
         $this->sources->add($envFromSource);
+
+        if ($external) {
+            $this->externalConfigurations->addSecret($secretName);
+        }
 
         return $this;
     }
@@ -252,6 +257,7 @@ readonly class EnvConfigurator
             $this->appRegistry,
             $this->envSourcesRegistry,
             $this->dispatcher,
+            $this->externalConfigurations,
             $externalSourcesTrackingContext
         );
     }

--- a/src/Core/Container/Env/ExternalConfigurationRegistry.php
+++ b/src/Core/Container/Env/ExternalConfigurationRegistry.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Dealroadshow\K8S\Framework\Core\Container\Env;
+
+class ExternalConfigurationRegistry
+{
+    /**
+     * @var array<string, false> An array, where keys are names of Kubernetes ConfigMaps that are external, which means they are optional during the generation of manifests, and values are false booleans (ignored)
+     */
+    private array $configMaps = [];
+
+    /**
+     * @var array<string, false> An array, where keys are names of Kubernetes Secrets that are external, which means they are optional during the generation of manifests, and values are false booleans (ignored)
+     */
+    private array $secrets = [];
+
+    public function addConfigMap(string $configMapName): void
+    {
+        $this->configMaps[$configMapName] = false;
+    }
+
+    public function hasConfigMap(string $configMapName): bool
+    {
+        return array_key_exists($configMapName, $this->configMaps);
+    }
+
+    public function addSecret(string $secretName): void
+    {
+        $this->secrets[$secretName] = false;
+    }
+
+    public function hasSecret(string $secretName): bool
+    {
+        return array_key_exists($secretName, $this->secrets);
+    }
+}


### PR DESCRIPTION
Adds a way to add external configurations via `EnvConficurator` and mark them as external in order to make them optional in interested subscribers, such as `ChecksumSubscriber` in K8S Bundle